### PR TITLE
Editing while reading (typos, consistency)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Newt DB, the amphibious database
 ================================
 
-Python objects above, Postgtresql JSONB below.
+Python objects above, PostgreSQL JSONB below.
 
 See http://www.newtdb.org
 

--- a/doc/fine-print.rst
+++ b/doc/fine-print.rst
@@ -26,7 +26,7 @@ natural as working with objects in memory.  This is done in two ways:
    states are discarded and will be reloaded with current state when
    they're accessed next.
 
-2. Object accesses and changes are detected my observing attribute
+2. Object accesses and changes are detected by observing attribute
    access.  This works very well for accesses, but can miss updates. For
    example, consider this class::
 
@@ -53,7 +53,7 @@ see:
 
   http://www.zodb.org/en/latest/guide/writing-persistent-objects.html
 
-Learn about indexing and querying Postgresql
+Learn about indexing and querying PostgreSQL
 ============================================
 
 By default, Newt creates a JSON index on your data.  Read about
@@ -139,7 +139,7 @@ transaction-execution forms that can be used.  See:
 
   http://www.zodb.org/en/latest/guide/transactions-and-threading.html
 
-For more information.
+for more information.
 
 .. [#maybe-match] In a more complex query, Postgres might evaluate the
    expression. It depends on what other indexes might be in play.

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -11,8 +11,8 @@ Next, install newt.db::
 
   pip install newt.db
 
-You'll eventually want to create dedicated database and database user for
-newt's use, but if you've installed Postgres locally, you can just use
+You'll eventually want to create a dedicated database and database user for
+Newt's use, but if you've installed Postgres locally, you can just use
 the default database.
 
 From Python, to get started::
@@ -20,11 +20,11 @@ From Python, to get started::
   >>> import newt.db
   >>> connection = newt.db.connection('')
 
-In this example, we've asked newt to connect to the default Postgres
+In this example, we've asked Newt to connect to the default Postgres
 database.  You can also supply a :doc:`connection string
 <topics/connection-strings>`.
 
-The connection has a root object:
+The connection has a root object::
 
   >>> connection.root
   <root: >
@@ -35,11 +35,11 @@ To add data, we simply add objects to the root, directly::
 
   >>> connection.root.first = newt.db.Object(name='My first object')
 
-Or indirect, as a subobject::
+Or indirectly, as a subobject::
 
   >>> connection.root.first.child = newt.db.Object(name='First child')
 
-When we're ready to save our data, we need to tell newt to commit the
+When we're ready to save our data, we need to tell Newt to commit the
 changes::
 
   >>> connection.commit()
@@ -71,10 +71,10 @@ Normally, you'd create application-specific objects by subclassing
 
 The ``Persistent`` base class helps track object changes. When we
 modify an object, by setting an attribute, the object is marked as
-changed, so that newt will write it to the database when your
+changed, so that Newt will write it to the database when your
 application commits changes.
 
-With a class like the one above, we can add tasks to the database:
+With a class like the one above, we can add tasks to the database::
 
    >>> conn.root.task = Task("First task", "Explain collections")
    >>> connection.commit()
@@ -94,12 +94,12 @@ create a task list::
     def add(self, task):
         self.tasks.append(task)
 
-Then when setting up our database, we'd do something like:
+Then when setting up our database, we'd do something like::
 
   >>> connection.root.tasks = TasksList()
   >>> connection.commit()
 
-In the TaskList class, we using a ``List`` object. This is similar to
+In the ``TaskList`` class, we using a ``List`` object. This is similar to
 a Python list, except that, like the ``Persistent`` base class, it
 tracks changes so they're saved when your application commits changes.
 
@@ -127,7 +127,7 @@ large, they spread their data over multiple database records, reducing
 the amount of data read and written and allowing collections that
 would be too large to keep in memory at once.
 
-With this, building up the database could look like:
+With this, building up the database could look like::
 
     >>> connection.root.lists = TaskLists()
     >>> connection.root.lists.add('docs', TaskList())
@@ -141,23 +141,23 @@ of the database by traversing from object to object.
 Searching
 =========
 
-Newt leverages Postgresql's powerful index and search
-capabilities. The simplest way to search is with a connections
+Newt leverages PostgreSQL's powerful index and search
+capabilities. The simplest way to search is with a connection's
 ``where`` method::
 
   >>> tasks = connection.where("""state @> '{"title": "First task"}'""")
 
 The search above used a Postgres JSON ``@>`` operator that tests
 whether its right side appears in its left side.  This sort of search
-is indexed automatically by newt.  You can also use the search method::
+is indexed automatically by newt.  You can also use the ``search`` method::
 
   >>> tasks = connection.search("""
   ...     select * from newt where state @> '{"title": "First task"}'
   ...     """)
 
-When using ``search``, you can compose any SQL you wish. but you the
+When using ``search``, you can compose any SQL you wish, but the
 result must contain columns ``zoid`` and ``ghost_pickle``.  When you
-first use a database with newt, it creates a number of tables,
+first use a database with Newt, it creates a number of tables,
 including ``newt``::
 
         Table "public.newt"
@@ -172,14 +172,14 @@ including ``newt``::
         "newt_json_idx" gin (state)
 
 The ``zoid`` column is the database primary key. Every persistent
-object in newt has a unique zoid.  The ``ghost_pickle`` pickle
+object in Newt has a unique zoid.  The ``ghost_pickle`` pickle
 contains minimal information to, along with ``zoid`` create newt
 objects. The ``class_name`` column contains object's class name, which
-can be useful for search.  The state column contains a JSON
+can be useful for search.  The ``state`` column contains a JSON
 representation of object state suitable for searching and access from
 other applications.
 
-You can use Postsresql to define more sophisticated or
+You can use PostgreSQL to define more sophisticated or
 application-specific indexes, as needed.
 
 Newt has a built-in helper for defining full-text indexes on your data::
@@ -195,14 +195,14 @@ index.  With the index in place, you can search it like this::
 
 The example above finds all of the objects containing the word
 "explain" in their title, description, or text.  We've assumed that
-these are tasks. If we wanted to make sure, we could add a class
+these are tasks. If we wanted to make sure, we could add a "class"
 restriction::
 
   >>> tasks = connection.where(
   ...   "mytext(state) @@ 'explain' and class = 'newt.demo.Task'")
 
-Rather than creating an index directly, we can ask newt to just return
-the Postgresql code to create them::
+Rather than creating an index directly, we can ask Newt to just return
+the PostgreSQL code to create them::
 
   >>> sql = connection.create_text_index_sql(
   ...           'mytext', ['title', 'description', 'text'])
@@ -246,10 +246,10 @@ database, you could use::
 Learning more
 =============
 
-To learn more about newt, see the newt topics and the newt
+To learn more about Newt, see the Newt topics and the Newt
 :doc:`topics <topics/index>` and :doc:`reference <reference>`.
 
 
 .. [#persistent] Newt makes ``Persistent`` available as an attribute,
    but it's an alias for ``persistent.Persistent``.  In fact many of
-   the classes provided by newt are just aliases.
+   the classes provided by Newt are just aliases.

--- a/doc/how-it-works.rst
+++ b/doc/how-it-works.rst
@@ -8,7 +8,7 @@ projects with years of production experience.
 
 ZODB is an object-oriented database for Python.  It provides
 transparent object persistence.  ZODB has a pluggable storage layer
-and newt leverages `RelStorage
+and Newt leverages `RelStorage
 <http://relstorage.readthedocs.io/en/latest/>`_ to store data in
 Postgres.
 
@@ -25,9 +25,9 @@ Newt adds a search API for searching the Postgres JSON data and
 returning persistent objects.  It also provides a convenience API for
 raw data searches.
 
-Finally, newt adds additional convenience APIs to more directly support
+Finally, Newt adds additional convenience APIs to more directly support
 it's intended audience.  These are intended to augment but not hide
 ZODB and RelStorage.  Some of these are just aliases.  It will be
-possible to integrate new with existing ZODB applications.
+possible to integrate Newt with existing ZODB applications.
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,7 +8,7 @@ Newt DB, the amphibious database
   Data are moved in and out of memory as needed, so databases can be
   as large as needed.
 
-- In Postgres: index and search your data using Postgresql, from within your
+- In Postgres: index and search your data using PostgreSQL, from within your
   application and externally.
 
 - Within your application, search results may be returned as

--- a/doc/roadmap.rst
+++ b/doc/roadmap.rst
@@ -6,15 +6,15 @@ Road map
 
 - Asynchronous updates
 
-  IF you have a lot of indexes to update, you'll be able to update
+  If you have a lot of indexes to update, you'll be able to update
   them asynchronously. This can be important if primary writes need to
   happen quickly.
 
-  The asynchronous updater will also make it easier to try out newt
-  with and migrate existing RelStorage applications.
+  The asynchronous updater will also make it easier to try out Newt
+  and migrate existing RelStorage applications.
 
 - Custom JSON generation
 
   There will be an API to customize how JSON data are generated. This
   can be especially helpful when using data that's not easy to
-  manipulate in Postgresql.
+  manipulate in PostgreSQL.

--- a/doc/topics/connection-strings.rst
+++ b/doc/topics/connection-strings.rst
@@ -7,14 +7,13 @@ Postgres documentation
 <https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING>`_.
 They take 2 forms:
 
-1. URL syntax
+1. URL syntax::
 
+     postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
 
-   ``postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]``
+2. Keyword/Value syntax::
 
-2. Keyword/Value syntax
-
-   ``host=localhost port=5432 dbname=mydb user=sally password=123456``
+     host=localhost port=5432 dbname=mydb user=sally password=123456
 
 All of the parameters have defaults and may be excluded.  An empty
 string is just an application of the keyword/value syntax with no

--- a/doc/topics/for-zodb-users.rst
+++ b/doc/topics/for-zodb-users.rst
@@ -10,7 +10,7 @@ Newt provides some significant enhancements to ZODB applications:
 - Access to data outside of Python.  Data are stored in a JSON
   representation that can be accessed by non-Python tools.
 
-- Fast powerful search, via Postgres SQL and indexes.
+- Fast, powerful search, via Postgres SQL and indexes.
 
 - Because indexes are maintained in Postgres rather than in the app,
   far fewer objects are stored in the database.

--- a/doc/topics/text-configuration.rst
+++ b/doc/topics/text-configuration.rst
@@ -28,12 +28,12 @@ Here's an example text configuration for Newt DB::
   </newtdb>
 
 The syntax used is based on the syntax used by web servers such as
-Apache and NGINX.  Elements, in angle brackets identify configuration
+Apache and NGINX.  Elements in angle brackets identify configuration
 objects with name-value pairs inside elements to specify options.
 Optional indentation indicates containment relationships and element
 start and end tags must appear on their own lines.
 
-Newt DB provides 2 configuration elements, ``newtdb`` and ``newt``.
+Newt DB provides two configuration elements: ``newtdb`` and ``newt``.
 These elements augment existing elements to provide extra behavior.
 
 newt
@@ -48,14 +48,14 @@ newtdb
 
 Some things to note:
 
-- An ``%import`` directives is used to load configuration schema for
+- An ``%import`` directive is used to load the configuration schema for
   Newt DB.
 
 - A ``keep-history`` option is used to request a history-free
   storage. History-free storages only keep current data and discard
   transaction meta data. History-preserving storages keep past data
   records until they are packed away and allow "time-travel" to view
-  data in the past.  History preserving storages are much slower and
+  data in the past.  History-preserving storages are much slower and
   require more maintenance.  Newt DB works with either
   history-preserving or history-free storages, but history-free
   storages are recommended and are the default for the Python API.


### PR DESCRIPTION
Spell PostgreSQL the way https://www.postgresql.org/ does.
The name "newt" was written with and without capital, let's always use
"Newt" to make it more obvious.