### PR TITLE
Compatibility with PyPy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 develop-eggs
 dist
 doc/_build
+eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
 addons:
   postgresql: "9.4"
 python:
+  - pypy-5.4.1
   - 3.6
   - 2.7
   - 3.5

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -112,3 +112,4 @@ Contributors
 ------------
 
 - Jim Fulton, 2017/01/24
+- Jason Madden, 2017/01/25

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 name, version = 'newt.db', '0.1.1'
 
-install_requires = ['setuptools', 'RelStorage[postgresql]', 'psycopg2', 'six']
+install_requires = ['setuptools', 'RelStorage[postgresql]', 'six']
 extras_require = dict(test=['manuel', 'mock', 'zope.testing', 'zc.zlibstorage'])
 
 entry_points = """
@@ -20,6 +20,8 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: Implementation :: CPython
+Programming Language :: Python :: Implementation :: PyPy
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules
 Operating System :: Microsoft :: Windows

--- a/src/newt/db/search.py
+++ b/src/newt/db/search.py
@@ -3,7 +3,7 @@
 It's assumed that the API is used with an object stored in a
 RelStorage with a Postgres back end.
 """
-import psycopg2
+
 import re
 from ZODB.utils import p64
 
@@ -172,6 +172,10 @@ def create_text_index(conn, fname, D, C=None, B=None, A=None):
         cursor.execute(sql)
         conn.commit()
     finally:
+        try:
+            cursor.close()
+        except Exception:
+            pass
         try:
             conn.close()
         except Exception:

--- a/src/newt/db/tests/base.py
+++ b/src/newt/db/tests/base.py
@@ -1,4 +1,7 @@
-import psycopg2
+from relstorage.adapters.postgresql import adapter
+import gc
+import sys
+PYPY = hasattr(sys, 'pypy_version_info')
 
 class DBSetup(object):
 
@@ -10,7 +13,7 @@ class DBSetup(object):
 
     def setUp(self):
         self.dbname = self.__class__.__name__.lower() + '_newt_test_database'
-        self.base_conn = psycopg2.connect('')
+        self.base_conn = adapter.select_driver().connect('')
         self.base_conn.autocommit = True
         self.base_cursor = self.base_conn.cursor()
         self.drop_db()
@@ -22,5 +25,13 @@ class DBSetup(object):
 
     def tearDown(self):
         super(DBSetup, self).tearDown()
+        if PYPY:
+            # Make sure there aren't any leaked connections around
+            # that would keep us from dropping the DB
+            # (https://travis-ci.org/newtdb/db/jobs/195267673)
+            # This needs a fix from RelStorage post 2.0.0.
+            gc.collect()
+            gc.collect()
         self.drop_db()
+        self.base_cursor.close()
         self.base_conn.close()


### PR DESCRIPTION
I notice that setup.py specifies both `RelStorage[postgresql]` and also `psycopg2`. The former will work correctly on PyPy, but the latter will not (you want `psycopg2cffi`).

There doesn't seem to be any actual usage of psycopg2 in the code itself, only in a test case:
```
newtdb$ ack psycopg2
setup.py
3:install_requires = ['setuptools', 'RelStorage[postgresql]', 'psycopg2', 'six']

src/newt/db/_search.py
6:import psycopg2

src/newt/db/tests/base.py
1:import psycopg2
13:        self.base_conn = psycopg2.connect('')
```

If you need to connect to a database in a test case, you could try this:
```
import relstorage.adapters.postgresql.adapter as adapter
self.base_conn = adapter.select_driver().connect('')
```

Then in theory you should Just Work with any supported driver, assuming you stick to the DB-API. Or at least, psyc2pg2 and psycopg2cffi pretty much implement the same extensions.

Adding `- pypy-5.4.1` to `.travis.yml` should run your tests on a new-ish pypy.