### PR TITLE
fix json decode error

### DIFF
--- a/src/newt/db/jsonpickle.py
+++ b/src/newt/db/jsonpickle.py
@@ -132,7 +132,7 @@ class Put(Get):
                 v = {'::': 'shared', 'id': self.id, 'value': v}
         return v
 
-def dt_bytes(v):
+def dt_bytes(v, *args):
     if isinstance(v, Bytes):
         v = v.data
     return v


### PR DESCRIPTION
args is not always a single object from `datetime.datetime(dt_bytes(*args)).isoformat()` for example