### PR TITLE
Fixed: datetime values with time zones weren't handled correctly.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,13 @@ See http://www.newtdb.org
 Changes
 =======
 
+0.2.0dev0 (unreleased)
+=======================
+
+- Added PyPy support
+
+- Fixed: ``datetime`` values with time zones weren't handled correctly.
+
 0.1.2 (2017-01-26)
 ==================
 

--- a/src/newt/db/jsonpickle.py
+++ b/src/newt/db/jsonpickle.py
@@ -65,11 +65,12 @@ class Global(object):
 
 class Instance(object):
 
-    id = state = None
+    id = None
 
-    def __init__(self, class_name, args):
+    def __init__(self, class_name, args, state=None):
         self.class_name = class_name
         self.args = args
+        self.state = state
 
     def __setstate__(self, state):
         self.state = state
@@ -137,6 +138,12 @@ def dt_bytes(v):
         v = v.data
     return v
 
+def datetime_(data, tz=None):
+    result = datetime.datetime(dt_bytes(data)).isoformat()
+    if tz is not None:
+        result = Instance("datetime", (), dict(value=result, tz=tz))
+    return result
+
 def reconstruct(args):
     (cls, base, state) = args
     ob = Instance(cls.name, ())
@@ -152,7 +159,7 @@ def handle_set(args):
 
 special_classes = {
     'datetime.datetime':
-    lambda args: datetime.datetime(dt_bytes(*args)).isoformat(),
+    lambda args: datetime_(*args),
     'datetime.date': lambda args: datetime.date(dt_bytes(*args)).isoformat(),
     '_codecs.encode': lambda args: _codecs.encode(*args),
     'copy_reg._reconstructor': reconstruct,

--- a/src/newt/db/tests/testjsonpickle.py
+++ b/src/newt/db/tests/testjsonpickle.py
@@ -208,6 +208,9 @@ class JsonUnpicklerProtocol0Tests(unittest.TestCase):
         got = JsonUnpickler(pickle.dumps(data, self.proto)).load()
         self.assertEqual(got, '[[1, 2, 3], [4, 5, 6]]')
 
+class TZ(datetime.tzinfo):
+    pass
+
 class JsonUnpicklerProtocol1Tests(JsonUnpicklerProtocol0Tests):
 
     def test_scalar_persistent_id(self):
@@ -220,6 +223,15 @@ class JsonUnpicklerProtocol1Tests(JsonUnpicklerProtocol0Tests):
             got,
             '[{"::": "persistent", "id": 18446744073709551615},'
             ' {"::": "persistent", "id": 18446744073709551615}]')
+
+    def test_dt_with_tz(self):
+        data = datetime.datetime(1, 2, 3, 4, 5, 6, 7, TZ())
+        got = JsonUnpickler(pickle.dumps(data, self.proto)).load(sort_keys=True)
+        self.assertEqual(
+            '{"::": "datetime",'
+            ' "tz": {"::": "newt.db.tests.testjsonpickle.TZ"},'
+            ' "value": "0001-02-03T04:05:06.000007"}',
+            got)
 
     proto = 1
 


### PR DESCRIPTION
This replaces https://github.com/newtdb/db/pull/4