### PR TITLE
Asynchronous updates and API to update external data (pub/sub for new data)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,18 +1,22 @@
 Changes
 =======
 
-0.2.2 (unreleased)
+0.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added an API for following database changes.
 
+- Exposed JSON conversion as an API that can be used to for other
+  applications than updating the newt table, like updating external
+  indexes.
+
+- Created a JSON conversion object to support conversion customization.
 
 0.2.1 (2017-02-06)
 ==================
 
 - Fixed: Packing wasn't handled correctly. Objects removed during
   packing weren't removed from the ``newt`` table.
-
 
 0.2.0 (2017-01-30)
 ==================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -13,6 +13,8 @@ newt.db module-level functions
 
 .. autofunction:: newt.db.storage
 
+.. autofunction:: newt.db.pg_connection
+
 .. autoclass:: newt.db.Connection
    :members: where, search, where_batch, search_batch, query_data,
              create_text_index_sql, create_text_index

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -38,7 +38,7 @@ newt.db.follow module-level functions
 =====================================
 
 .. automodule:: newt.db.follow
-   :members: updates, get_progress_tid, set_progress_tid
+   :members: updates, get_progress_tid, set_progress_tid, listen
 
 newt.db.jsonpickle module-level functions
 =========================================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -2,6 +2,8 @@
 Reference
 =========
 
+.. contents::
+
 newt.db module-level functions
 ==============================
 
@@ -29,3 +31,18 @@ newt.db.search module-level functions
 .. automodule:: newt.db.search
    :members: search, search_batch,
              create_text_index_sql, create_text_index
+
+newt.db.follow module-level functions
+=====================================
+
+.. automodule:: newt.db.follow
+   :members: updates
+
+newt.db.jsonpickle module-level functions
+=========================================
+
+.. automodule:: newt.db.jsonpickle
+   :members: JsonUnpickler, Jsonifier
+
+   .. autoclass:: newt.db.jsonpickle.Jsonifier
+      :members: __init__, __call__

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -38,7 +38,7 @@ newt.db.follow module-level functions
 =====================================
 
 .. automodule:: newt.db.follow
-   :members: updates
+   :members: updates, get_progress_tid, set_progress_tid
 
 newt.db.jsonpickle module-level functions
 =========================================

--- a/doc/topics/admin.rst
+++ b/doc/topics/admin.rst
@@ -16,6 +16,8 @@ Docker images, which have self-contained PostgreSQL installations.
 Simple binary installations are a good choice for development
 environments.
 
+.. _packing-reference-label:
+
 Packing
 =======
 
@@ -69,7 +71,3 @@ For more information, see the `zodbpack documentation
    container in a separate transaction. In this case, the object is
    temporarily garbage and, if you're unlucky, it could be garbage
    collection while temporarily garbage.
-
-
-
-

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -2,7 +2,7 @@
 Follow changes in ZODB RelStorage PostgreSQL databases
 ======================================================
 
-The ``newt.db.follow`` package provides an API for subscribing to
+The :py:mod:`newt.db.follow` module provides an API for subscribing to
 database changes .
 
 It's used by newt.db for asynchronous updates, but it can be used for
@@ -23,7 +23,8 @@ other applications, such as:
   >>> c.commit()
   >>> c.close()
 
-Usage::
+You can get an iterator of changes by calling the
+:py:func:`~newt.db.follow.updates` function::
 
   >>> import newt.db
   >>> import newt.db.follow
@@ -38,10 +39,10 @@ Usage::
 
    >>> connection.close()
 
-The reason the updater returns batches to facilitate batch processing
-of data while processing data as soon as possible.  Batches are as
-large as possible, limited loosly by a target batch size with the
-constraint that batches aren't split between batches.  Batches are
+The updates iterator returns batches to facilitate batch processing of
+data while processing data as soon as possible.  Batches are as large
+as possible, limited loosly by a target batch size with the constraint
+that transactions aren't split between batches.  Batches are
 themselves iterators.
 
 The interator can run over a range of transactions, or can run
@@ -61,13 +62,13 @@ We can update the example above::
   >>> import newt.db.follow
   >>> import newt.db.jsonpickle
 
-  | >>> connection = newt.db.pg_connection(dsn)
-  | >>> jsonifier = newt.db.jsonpickle.Jsonifier()
-  | >>> for batch in newt.db.follow.updates(connection):
-  | ...     for tid, zoid, data in batch:
-  | ...         class_name, _, data = jsonifier(zoid, data)
-  | ...         if data is not None:
-  | ...             print_(zoid, class_name, data)
+  >>> connection = newt.db.pg_connection(dsn)
+  >>> jsonifier = newt.db.jsonpickle.Jsonifier()
+  >>> for batch in newt.db.follow.updates(connection):
+  ...     for tid, zoid, data in batch:
+  ...         class_name, _, data = jsonifier((zoid, tid), data)
+  ...         if data is not None:
+  ...             print_(zoid, class_name, data)
   0 persistent.mapping.PersistentMapping {"data": {"x": 1}}
 
 :py:class:`Jsonifiers <newt.db.jsonpickle.Jsonifier>` take a label
@@ -83,6 +84,41 @@ be ``None`` if:
 - the object class was one the JSON conversion skipped, or
 
 - There was an error converting the data.
+
+Tracking progress
+=================
+
+.. setup
+
+  >>> newt.db.follow.get_progress_tid(connection, 'mypackage.mymodule')
+  -1
+
+Often the data returned by the ``updates`` iterator is used to update
+some other data.  Often clients will be stopped and later restarted
+and need to keep track of where they left off.  The
+:py:func:`~newt.db.follow.set_progress_tid` method can be used to save
+progress for a client::
+
+  >>> newt.db.follow.set_progress_tid(connection, 'mypackage.mymodule', tid)
+
+The first argument is a PostgreSQL database connection.  The second
+argument is a client identifier, typically the dotted name of the
+client module.  The third argument is the last transaction id that was
+processed.
+
+Later, you can use :py:func:`~newt.db.follow.get_progress_tid` to retrieve
+the saved transaction id::
+
+  >>> start_tid = newt.db.follow.get_progress_tid(
+  ...   connection, 'mypackage.mymodule')
+
+.. check
+
+   >>> start_tid == tid
+   True
+
+You'd then pass the retrieved transaction identifier as the
+``start_tid`` argument to :py:func:`~newt.db.follow.updates`.
 
 .. tearDown
 

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -22,7 +22,8 @@ Usage::
   >>> connection = psycopg2.connect('')
   >>> for batch in newt.db.follow.updates(connection):
   ...     for tid, zoid, data in batch:
-  ...         print(tid, zoid, len(data))
+  ...         print_(zoid, len(data))
+  0 66
 
 The reason the updater returns batches to facilitate batch processing
 of data while processing data as soon as possible.  Batches are as
@@ -51,9 +52,10 @@ We can update the example above::
   >>> jsonifier = newt.db.jsonpickle.Jsonifier()
   >>> for batch in newt.db.follow.updates(connection):
   ...     for tid, zoid, data in batch:
-  ...         class_name, _, data = jsonifier(oid, data)
+  ...         class_name, _, data = jsonifier(zoid, data)
   ...         if data is not None:
-  ...             print(tid, zoid, class_name, data)
+  ...             print_(zoid, class_name, data)
+  0 persistent.mapping.PersistentMapping {"data": {"x": 1}}
 
 :py:class:`Jsonifiers <newt.db.jsonpickle.Jsonifier>` take a label
 (used for logging errors) and data and return a class_name, a ghost

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -15,15 +15,28 @@ other applications, such as:
 
 - monitoring or analytics of data changes.
 
+.. setup
+
+  >>> import newt.db
+  >>> c = newt.db.connection(dsn)
+  >>> c.root.x = 1
+  >>> c.commit()
+  >>> c.close()
+
 Usage::
 
   >>> import newt.db.follow
+  >>> import pickle
   >>> import psycopg2
-  >>> connection = psycopg2.connect('')
+  >>> connection = psycopg2.connect(dsn)
   >>> for batch in newt.db.follow.updates(connection):
   ...     for tid, zoid, data in batch:
-  ...         print_(zoid, len(data))
-  0 66
+  ...         print_(zoid, pickle.loads(data).__name__)
+  0 PersistentMapping
+
+.. cleanup
+
+   >>> connection.close()
 
 The reason the updater returns batches to facilitate batch processing
 of data while processing data as soon as possible.  Batches are as
@@ -48,7 +61,7 @@ We can update the example above::
   >>> import newt.db.jsonpickle
   >>> import psycopg2
 
-  >>> connection = psycopg2.connect('')
+  >>> connection = psycopg2.connect(dsn)
   >>> jsonifier = newt.db.jsonpickle.Jsonifier()
   >>> for batch in newt.db.follow.updates(connection):
   ...     for tid, zoid, data in batch:
@@ -71,3 +84,6 @@ be ``None`` if:
 
 - There was an error converting the data.
 
+.. tearDown
+
+   >>> connection.close()

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -1,0 +1,37 @@
+======================================================
+Follow changes in ZODB RelStorage PostgreSQL databases
+======================================================
+
+The ``newt.db.follow`` package provides an API for subscribing to
+database changes .
+
+It's used by newt.db for asynchronous updates, but it can be used for
+other applications, such as:
+
+- creating data indexes, such as Elasticsearch indexes.
+
+- creating alternate representations, such as relational models to
+  support other applications.
+
+- monitoring or analytics of data changes.
+
+Usage::
+
+  >>> import newt.db.follow
+  >>> import psycopg2
+  >>> connection = psycopg2.connect('')
+  >>> for batch in newt.db.follow.updates(connection):
+  ...     for tid, zoid, data in batch:
+  ...         print(tid, zoid, len(data))
+
+The reason the updater returns batches to facilitate batch processing
+of data while processing data as soon as possible.  Batches are as
+large as possible, limited loosly by a target batch size with the
+constraint that batches aren't split between batches.  Batches are
+themselves iterators.
+
+The interator can run over a range of transactions, or can run
+indefinately, returning new batches as new data are committed.
+
+See the :py:func:`updates reference <newt.db.follow.updates>` for
+detailed documentation.

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -25,10 +25,10 @@ other applications, such as:
 
 Usage::
 
+  >>> import newt.db
   >>> import newt.db.follow
   >>> import pickle
-  >>> import psycopg2
-  >>> connection = psycopg2.connect(dsn)
+  >>> connection = newt.db.pg_connection(dsn)
   >>> for batch in newt.db.follow.updates(connection):
   ...     for tid, zoid, data in batch:
   ...         print_(zoid, pickle.loads(data).__name__)
@@ -57,17 +57,17 @@ The data returned by the follower is a pickle, which probably isn't
 very useful.  You can convert it to JSON using Newt's JSON conversion.
 We can update the example above::
 
+  >>> import newt.db
   >>> import newt.db.follow
   >>> import newt.db.jsonpickle
-  >>> import psycopg2
 
-  >>> connection = psycopg2.connect(dsn)
-  >>> jsonifier = newt.db.jsonpickle.Jsonifier()
-  >>> for batch in newt.db.follow.updates(connection):
-  ...     for tid, zoid, data in batch:
-  ...         class_name, _, data = jsonifier(zoid, data)
-  ...         if data is not None:
-  ...             print_(zoid, class_name, data)
+  | >>> connection = newt.db.pg_connection(dsn)
+  | >>> jsonifier = newt.db.jsonpickle.Jsonifier()
+  | >>> for batch in newt.db.follow.updates(connection):
+  | ...     for tid, zoid, data in batch:
+  | ...         class_name, _, data = jsonifier(zoid, data)
+  | ...         if data is not None:
+  | ...             print_(zoid, class_name, data)
   0 persistent.mapping.PersistentMapping {"data": {"x": 1}}
 
 :py:class:`Jsonifiers <newt.db.jsonpickle.Jsonifier>` take a label

--- a/doc/topics/following.rst
+++ b/doc/topics/following.rst
@@ -26,18 +26,12 @@ other applications, such as:
 You can get an iterator of changes by calling the
 :py:func:`~newt.db.follow.updates` function::
 
-  >>> import newt.db
   >>> import newt.db.follow
   >>> import pickle
-  >>> connection = newt.db.pg_connection(dsn)
-  >>> for batch in newt.db.follow.updates(connection):
+  >>> for batch in newt.db.follow.updates(dsn):
   ...     for tid, zoid, data in batch:
   ...         print_(zoid, pickle.loads(data).__name__)
   0 PersistentMapping
-
-.. cleanup
-
-   >>> connection.close()
 
 The updates iterator returns batches to facilitate batch processing of
 data while processing data as soon as possible.  Batches are as large
@@ -58,13 +52,11 @@ The data returned by the follower is a pickle, which probably isn't
 very useful.  You can convert it to JSON using Newt's JSON conversion.
 We can update the example above::
 
-  >>> import newt.db
   >>> import newt.db.follow
   >>> import newt.db.jsonpickle
 
-  >>> connection = newt.db.pg_connection(dsn)
   >>> jsonifier = newt.db.jsonpickle.Jsonifier()
-  >>> for batch in newt.db.follow.updates(connection):
+  >>> for batch in newt.db.follow.updates(dsn):
   ...     for tid, zoid, data in batch:
   ...         class_name, _, data = jsonifier((zoid, tid), data)
   ...         if data is not None:
@@ -88,18 +80,13 @@ be ``None`` if:
 Tracking progress
 =================
 
-.. setup
-
-  >>> newt.db.follow.get_progress_tid(connection, 'mypackage.mymodule')
-  -1
-
 Often the data returned by the ``updates`` iterator is used to update
 some other data.  Often clients will be stopped and later restarted
 and need to keep track of where they left off.  The
 :py:func:`~newt.db.follow.set_progress_tid` method can be used to save
 progress for a client::
 
-  >>> newt.db.follow.set_progress_tid(connection, 'mypackage.mymodule', tid)
+  >>> newt.db.follow.set_progress_tid(dsn, 'mypackage.mymodule', tid)
 
 The first argument is a PostgreSQL database connection.  The second
 argument is a client identifier, typically the dotted name of the
@@ -109,8 +96,7 @@ processed.
 Later, you can use :py:func:`~newt.db.follow.get_progress_tid` to retrieve
 the saved transaction id::
 
-  >>> start_tid = newt.db.follow.get_progress_tid(
-  ...   connection, 'mypackage.mymodule')
+  >>> start_tid = newt.db.follow.get_progress_tid(dsn, 'mypackage.mymodule')
 
 .. check
 
@@ -119,7 +105,3 @@ the saved transaction id::
 
 You'd then pass the retrieved transaction identifier as the
 ``start_tid`` argument to :py:func:`~newt.db.follow.updates`.
-
-.. tearDown
-
-   >>> connection.close()

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -7,8 +7,9 @@ Newt DB Topics
 
    connection-strings
    text-configuration
+   admin
    schemas
    for-zodb-users
-   admin
+   following
 
 .. todo:

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -11,5 +11,6 @@ Newt DB Topics
    schemas
    for-zodb-users
    following
+   updater
 
 .. todo:

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -10,7 +10,7 @@ Newt DB Topics
    admin
    schemas
    for-zodb-users
-   following
    updater
+   following
 
 .. todo:

--- a/doc/topics/updater.rst
+++ b/doc/topics/updater.rst
@@ -1,0 +1,164 @@
+============================
+Asynchronous JSON conversion
+============================
+
+Normally, newt converts data to JSON as it's saved in the database.
+In turn, any indexes defined on the JSON data are updated at the same
+time.  With the default JSON index, informal tests show Newt DB write
+performance to be around 10 percent slower than RelStorage. Adding a
+text index brought the performance down to the point where writes took
+twice as long, but were still fairly fast, several hundred per second
+on a laptop.
+
+If you have a lot of indexes to update or write performance is
+critical, you may want to leverage Newt DB's ability to update the
+JSON data asynchronously.  Doing so, allows the primary transactions
+to execute more quickly.
+
+Updating indexes asynchronously will usually be more efficient,
+because Newt DB's asynchronous updater batches updates. When indexes
+are updated for many objects in the same transaction, less data has to
+be written per transaction.
+
+If you want to try New DB, with an existing RelStorage/PostgreSQL
+database, you can use the updater to populate Newt DB without changing
+your application and introduce the use of Newt DB's search API
+gradually.
+
+There are some caveats however:
+
+- Because updates are asynchronous, search results may not always
+  reflect the current data.
+
+- Packing requires some special care, as will be discussed below.
+
+- You'll need to run a separate daemon, ``newt-updater`` in addition
+  to your database server.
+
+.. contents::
+
+Using Newt's Asynchronous Updater
+=================================
+
+To use Newt's asynchronous updater:
+
+- Omit ``newt`` tag from your database configuration, as in::
+
+    %import newt.db
+
+    <newtdb foo>
+      <zodb>
+        <relstorage>
+          keep-history false
+          <postgresql>
+            dsn postgresql://localhost/mydb
+          </postgresql>
+        </relstorage>
+      </zodb>
+    </newtdb>
+
+- Run the ``newt-updater`` script::
+
+    newt-updater postgresql://localhost/mydb
+
+  You'll want to run this using a daemonizer like `supervisord
+  <http://supervisord.org/>`_ or `ZDaemon
+  <https://pypi.python.org/pypi/zdaemon>`_.
+
+``newt-updater`` has a number of options:
+
+-l, --logging-configuration
+  Logging configuration.
+
+  This can be a log level, like ``INFO`` (the default), or the path to
+  a `ZConfig logging configuration file
+  <https://pypi.python.org/pypi/ZConfig>`_.
+
+-g, --gc-only
+  Collect garbage and exit.
+
+  This removes Newt DB records that don't have corresponding database records.
+  This is done by executing::
+
+    delete from newt n where not exists (
+      select from object_state s where n.zoid = s.zoid)
+
+  Note that garbage collection is normally performed on startup unless
+  the -G option is used.
+
+-G, --no-gc
+  Don't perform garbage collection on startup.
+
+--nagios
+  Check the status of the updater.
+
+  The status is checked by checking the updater lag, which is the
+  difference between the last transaction committed to the database, and
+  the last transaction processed by the updater.  The option takes 2
+  numbers, separated by commas.  The first number is the lag, in
+  seconds, for the updater to be considered to be OK.  The second number
+  is the maximum lag for which the updater isn't considered to be in
+  error. For example, 1,99 indicates OK if 1 or less, WARNING if more
+  than 1 and less than or equal to 99 and ERROR of more than 99 seconds.
+
+-t, --poll-timeout
+  Specify a poll timeout, in seconds.
+
+  Normally, the updater is notified to poll for changes.  If it
+  doesn't get notified in poll-timeout seconds, it will poll anyway.
+  This is a backstop to PostgreSQL's notification. The default timeout
+  is 300 seconds.
+
+-T, --remove-delete-trigger
+  Remove the Newt DB delete trigger, if it exists.
+
+  The Newt DB delete trigger is incompatible with the updater.  It can cause
+  deadlock errors is packed while the updater is running.  This option
+  is needed if you set up Newt DB normally, and then decided that you
+  wanted update Newt DB asynchronously.
+
+-d, --driver
+    Provide an explicit Postgres driver name (psycopg2 or
+    psycopg2cffi).  By default, the appropriate driver will be
+    selected automatically.
+
+Garbage collection
+==================
+
+See the topic on :doc:`packing`.
+
+The asynchronous updater tracks new database inserts and updates.
+When a database is packed, records are removed without generating
+updates.  Those deletes won't be reflected in the Newt DB.  You can
+tell the updater to clean up Newt DB records for which there are
+no-longer database records by either restarting it, or running it with
+the ``-g`` option::
+
+  newt-updater -g postgresql://localhost/mydb
+
+This tells the updater to just collect garbage.  You'll probably want
+to run this right after running `zodbpack
+<http://relstorage.readthedocs.io/en/latest/zodbpack.html>`_.
+
+Monitoring
+==========
+
+When running an external updater, like ``newt-updater``, you'll want
+to have some way to monitor that it's working correctly.  The
+``--nagios`` option ``newt-updater`` script can be used to provide a
+`Nagios Plugin
+<https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html>`_::
+
+  newt-updater postgresql://localhost/mydb --nagios 3,99
+
+The argument to the ``--nagios`` option is a pair of numbers giving
+limits for OK and warning alerts.  They're based on how far behind the
+updater is.  For example, with the example above, the monitor
+considers the updater to be OK if it is 3 seconds behind or less, in
+error if it is more than 99 seconds behind and of concern otherwise.
+
+Any monitoring system compatible with the Nagios plugin API can be
+used.
+
+The monitor output includes the lag, how far behind the updater is, in
+seconds as a performance metric.

--- a/doc/topics/updater.rst
+++ b/doc/topics/updater.rst
@@ -125,14 +125,12 @@ To use Newt's asynchronous updater:
 Garbage collection
 ==================
 
-See the topic on :doc:`packing`.
-
 The asynchronous updater tracks new database inserts and updates.
-When a database is packed, records are removed without generating
-updates.  Those deletes won't be reflected in the Newt DB.  You can
-tell the updater to clean up Newt DB records for which there are
-no-longer database records by either restarting it, or running it with
-the ``-g`` option::
+When a database is :ref:`packed <packing-reference-label>`, records are
+removed without generating updates.  Those deletes won't be reflected
+in the Newt DB.  You can tell the updater to clean up Newt DB records
+for which there are no-longer database records by either restarting
+it, or running it with the ``-g`` option::
 
   newt-updater -g postgresql://localhost/mydb
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ install_requires = ['setuptools', 'RelStorage[postgresql]', 'six']
 extras_require = dict(test=['manuel', 'mock', 'zope.testing', 'zc.zlibstorage'])
 
 entry_points = """
+[console_scripts]
+newt-updater = newt.db.updater:main
 """
 
 from setuptools import setup

--- a/src/newt/db/__init__.py
+++ b/src/newt/db/__init__.py
@@ -1,5 +1,5 @@
 from . import _ook; del _ook # Monkey patches
-from ._db import connection, DB, storage, Connection
+from ._db import connection, DB, storage, Connection, pg_connection
 from ._object import Object
 from persistent import Persistent
 from persistent.list import PersistentList as List

--- a/src/newt/db/_adapter.py
+++ b/src/newt/db/_adapter.py
@@ -3,6 +3,7 @@ import relstorage.adapters.postgresql.mover
 import relstorage.adapters.postgresql.schema
 
 from .jsonpickle import Jsonifier
+from ._util import trigger_exists
 
 class Adapter(relstorage.adapters.postgresql.PostgreSQLAdapter):
 
@@ -139,10 +140,7 @@ class SchemaInstaller(
     def update_schema(self, cursor, tables):
         if 'newt' not in tables:
             self._create_newt(cursor)
-        cursor.execute(
-            "select 1 from pg_catalog.pg_trigger "
-            "where tgname = 'newt_delete_on_state_delete_trigger'")
-        if not list(cursor):
+        if not trigger_exists(cursor, 'newt_delete_on_state_delete_trigger'):
             _create_newt_delete_trigger(cursor, self.keep_history)
 
     def drop_all(self):

--- a/src/newt/db/_adapter.py
+++ b/src/newt/db/_adapter.py
@@ -105,6 +105,15 @@ end;
 $$ language plpgsql;
 """
 
+_newt_ddl = """\
+create table newt (
+  zoid bigint primary key,
+  class_name text,
+  ghost_pickle bytea,
+  state jsonb);
+create index newt_json_idx on newt using gin (state);
+"""
+
 def _create_newt_delete_trigger(cursor, keep_history):
     cursor.execute(
         _newt_delete_on_state_delete_HP if keep_history else
@@ -117,14 +126,7 @@ def _create_newt_delete_trigger(cursor, keep_history):
 
 def create_newt(cursor, keep_history=None):
     keep_history = determine_keep_history(cursor, keep_history)
-    cursor.execute("""
-    create table newt (
-      zoid bigint primary key,
-      class_name text,
-      ghost_pickle bytea,
-      state jsonb);
-    create index newt_json_idx on newt using gin (state);
-    """)
+    cursor.execute(_newt_ddl)
     _create_newt_delete_trigger(cursor, keep_history)
 
 class SchemaInstaller(

--- a/src/newt/db/_adapter.py
+++ b/src/newt/db/_adapter.py
@@ -129,16 +129,6 @@ def create_newt(cursor, keep_history):
 class SchemaInstaller(
     relstorage.adapters.postgresql.schema.PostgreSQLSchemaInstaller):
 
-    def _create_newt(self, cursor):
-        cursor.execute("""
-        create table newt (
-          zoid bigint primary key,
-          class_name text,
-          ghost_pickle bytea,
-          state jsonb);
-        create index newt_json_idx on newt using gin (state);
-        """)
-
     def create(self, cursor):
         super(SchemaInstaller, self).create(cursor)
         create_newt(cursor, self.keep_history)

--- a/src/newt/db/_adapter.py
+++ b/src/newt/db/_adapter.py
@@ -115,7 +115,8 @@ def _create_newt_delete_trigger(cursor, keep_history):
       execute procedure newt_delete_on_state_delete();
     """)
 
-def create_newt(cursor, keep_history):
+def create_newt(cursor, keep_history=None):
+    keep_history = determine_keep_history(cursor, keep_history)
     cursor.execute("""
     create table newt (
       zoid bigint primary key,
@@ -150,3 +151,15 @@ class SchemaInstaller(
                 )
         self.connmanager.open_and_call(callback)
         super(SchemaInstaller, self).drop_all()
+
+def determine_keep_history(cursor, keep_history=None):
+    """Determine whether the RelStorage databases is set to keep history.
+    """
+    if keep_history is None:
+        # We don't know, so sniff
+        cursor.execute(
+            "select 1 from pg_catalog.pg_class "
+            "where relname = 'current_object'")
+        keep_history = bool(list(cursor))
+
+    return keep_history

--- a/src/newt/db/_db.py
+++ b/src/newt/db/_db.py
@@ -1,3 +1,4 @@
+import relstorage.adapters.postgresql
 import relstorage.storage
 import relstorage.options
 import ZODB
@@ -139,6 +140,7 @@ class Connection:
         return self.search_batch("select * from newt where " + query_tail,
                                  args, batch_start, batch_size)
 
+
 def _split_options(
     # DB options
     pool_size=7,
@@ -210,3 +212,14 @@ def connection(dsn, **kw):
     return Connection(
         ZODB.connection(storage(dsn, **storage_options), **db_options)
         )
+
+def pg_connection(dsn, driver_name='auto'):
+    """Create a PostgreSQL (not newt) database connection
+
+    This function should be used rather than, for example, calling
+    ``psycopg2.connect``, because it can use other Postgres drivers
+    depending on the Python environment and available modules.
+    """
+    options = relstorage.options.Options(driver=driver_name)
+    driver = relstorage.adapters.postgresql.select_driver(options)
+    return driver.connect(dsn)

--- a/src/newt/db/_util.py
+++ b/src/newt/db/_util.py
@@ -12,12 +12,16 @@ def closing(thing):
         except Exception:
             pass
 
-def table_exists(conn, name):
-    with closing(conn.cursor()) as cursor:
-        cursor.execute("""
-        select from information_schema.tables
-        where table_schema = 'public' AND table_name = %s
-        """, (name, ))
-        return bool(list(cursor))
+def table_exists(cursor, name):
+    cursor.execute(
+        "select from information_schema.tables "
+        "where table_schema = 'public' AND table_name = %s",
+        (name, ))
+    return bool(list(cursor))
 
-        
+def trigger_exists(cursor, name):
+    cursor.execute(
+        "select from pg_catalog.pg_trigger "
+        "where tgname = %s",
+        (name, ))
+    return bool(list(cursor))

--- a/src/newt/db/_util.py
+++ b/src/newt/db/_util.py
@@ -1,0 +1,13 @@
+import contextlib
+
+@contextlib.contextmanager
+def closing(thing):
+    """Like contextlib.closing except hides errors raised by close
+    """
+    try:
+        yield thing
+    finally:
+        try:
+            thing.close()
+        except Exception:
+            pass

--- a/src/newt/db/_util.py
+++ b/src/newt/db/_util.py
@@ -11,3 +11,13 @@ def closing(thing):
             thing.close()
         except Exception:
             pass
+
+def table_exists(conn, name):
+    with closing(conn.cursor()) as cursor:
+        cursor.execute("""
+        select from information_schema.tables
+        where table_schema = 'public' AND table_name = %s
+        """, (name, ))
+        return bool(list(cursor))
+
+        

--- a/src/newt/db/follow.py
+++ b/src/newt/db/follow.py
@@ -1,0 +1,175 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+def non_empty_generator(gen):
+    try:
+        first = next(gen)
+    except StopIteration:
+        return None
+    def it():
+        yield first
+        for v in gen:
+            yield v
+    return it()
+
+trigger_sql = """
+create function newt_notify_object_state_changed() returns trigger
+as $$
+begin
+  perform pg_notify('newt_object_state_changed', NEW.tid::text);
+  return NEW;
+end;
+$$ language plpgsql;
+
+create trigger newt_trigger_notify_object_state_changed
+  after insert or update on object_state for each row
+  execute procedure newt_notify_object_state_changed();
+"""
+
+class Updates:
+
+    def __init__(self, conn, start_tid=-1, end_tid=None,
+                 batch_limit=100000, internal_batch_size=100,
+                 poll_timeout=300):
+        self.conn = conn
+        self.cursor = conn.cursor()
+        self.ex = self.cursor.execute
+        self.tid = start_tid
+        self.follow = end_tid is None
+        self.end_tid = end_tid or 1<<62
+        self.poll_timeout = poll_timeout
+        self.batch_limit = batch_limit
+        self.internal_batch_size = internal_batch_size
+        if end_tid is None:
+            self.ex(
+                "select 1 from pg_trigger "
+                "where tgname = 'newt_trigger_notify_object_state_changed'")
+            if not list(self.cursor):
+                self.ex(trigger_sql)
+            self.conn.commit()
+
+    def _batch(self):
+        tid = self.tid
+        self.ex('begin')
+        try:
+            updates = self.conn.cursor('object_state_updates')
+            updates.itersize = self.internal_batch_size
+            try:
+                updates.execute("""\
+                select tid, zoid, state from object_state
+                where tid > %s and tid <= %s order by tid
+                """, (tid, self.end_tid))
+            except Exception:
+                logger.exception("Getting updates after %s", tid)
+                self.ex('rollback')
+                raise
+
+            n = 0
+            for row in updates:
+                if row[0] != tid:
+                    if n >= self.batch_limit:
+                        break
+                    tid = self.tid = row[0]
+                yield row
+                n += 1
+        finally:
+            try:
+                self.conn.rollback()
+                updates.close()
+            except Exception:
+                pass
+
+    def _listen(self):
+        conn = psycopg2.connect(self.conn.dsn)
+        try:
+            conn.set_isolation_level(
+                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            curs = conn.cursor()
+            curs.execute("LISTEN newt_object_state_changed")
+            timeout = self.poll_timeout
+
+            while True:
+                if select.select([conn], (), (), timeout) == ([], [], []):
+                    yield None
+                else:
+                    conn.poll()
+                    if conn.notifies:
+                        if any(n.payload == 'STOP' for n in conn.notifies):
+                            return # for tests
+                        # yield the last
+                        yield conn.notifies[-1].payload
+        finally:
+            conn.close()
+
+    def __iter__(self):
+        # Catch up:
+        while True:
+            batch = non_empty_generator(self._batch())
+            if batch is None:
+                break # caught up
+            else:
+                yield batch
+
+        if self.follow:
+            for payload in self._listen():
+                batch = non_empty_generator(self._batch())
+                if batch is not None:
+                    yield batch
+
+def updates(conn, start_tid=-1, end_tid=None,
+            batch_limit=100000, internal_batch_size=100,
+            poll_timeout=300):
+    """Create a data-update iterator
+
+    The iterator returns an iterator of batchs, where each batch is an
+    iterator of records. Each record is a triple consisting of an
+    integer transaction id, integer object id and data.  A sample
+    use::
+
+      >>> import newt.db.follow
+      >>> import psycopg2
+      >>> connection = psycopg2.connect('')
+      >>> for batch in newt.db.follow.updates(connection):
+      ...     for tid, zoid, data in batch:
+      ...         print(tid, zoid, len(data))
+
+
+
+    If no ``end_tid`` is provided, the iterator will iterate until
+    interrupted.
+
+    Parameters:
+
+    conn
+      A psycopg2 database connection.
+
+    start_tid
+      Start tid, expressed as an integer.  The iterator starts at the
+      first transaction **after** this tid.
+
+    end_tid
+      End tid, expressed as an integer.  The iterator stops at this, or at
+      the end of data, whichever is less.  If the end tid is None, the
+      iterator will run indefinately, returning new data as they are
+      committed.
+
+    batch_limit
+      A soft batch size limit.  When a batch reaches this limit, it will
+      end at the next transaction boundary.  The purpose of this limit is to
+      limit read-transaction size.
+
+    internal_batch_size
+      The size of the internal Postgres iterator.  Data aren't loaded from
+      Postgres all at once.  Server-side cursors are used and data are
+      loaded from the server in ``internal_batch_size`` batches.
+
+    poll_timeout
+      When no ``end_tid`` is specified, this specifies how often to poll
+      for changes.  Note that a trigger is created and used to notify the
+      iterator of changes, so changes ne detected quickly. The poll
+      timeout is just a backstop.
+    """
+
+    return Updates(conn, start_tid, end_tid, batch_limit, internal_batch_size,
+                   poll_timeout)

--- a/src/newt/db/follow.py
+++ b/src/newt/db/follow.py
@@ -1,5 +1,6 @@
 import logging
-import psycopg2
+
+from . import pg_connection
 
 logger = logging.getLogger(__name__)
 
@@ -107,10 +108,9 @@ class Updates:
         None values indicate that ``poll_interval`` seconds have
         passed since the last update.
         """
-        conn = psycopg2.connect(self.conn.dsn)
+        conn = pg_connection(self.conn.dsn)
         try:
-            conn.set_isolation_level(
-                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            conn.autocommit = True
             curs = conn.cursor()
             curs.execute("LISTEN newt_object_state_changed")
             from select import select
@@ -158,9 +158,9 @@ def updates(conn, start_tid=-1, end_tid=None,
     integer transaction id, integer object id and data.  A sample
     use::
 
+      >>> import newt.db
       >>> import newt.db.follow
-      >>> import psycopg2
-      >>> connection = psycopg2.connect('')
+      >>> connection = newt.db.pg_connection('')
       >>> for batch in newt.db.follow.updates(connection):
       ...     for tid, zoid, data in batch:
       ...         print(tid, zoid, len(data))
@@ -171,7 +171,7 @@ def updates(conn, start_tid=-1, end_tid=None,
     Parameters:
 
     conn
-      A psycopg2 database connection.
+      A Postgres database connection.
 
     start_tid
       Start tid, expressed as an integer.  The iterator starts at the

--- a/src/newt/db/follow.py
+++ b/src/newt/db/follow.py
@@ -302,3 +302,10 @@ def stop_updates(conn):
     """
     with closing(conn.cursor()) as cursor:
         cursor.execute("notify %s, 'STOP'" % NOTIFY)
+
+def garbage(dsn):
+    with closing(pg_connection(dsn)) as conn:
+        with closing(conn.cursor('find_garbage')) as cursor:
+            cursor.execute("select zoid from pack_object where not keep")
+            for r in cursor:
+                yield r[0]

--- a/src/newt/db/follow.py
+++ b/src/newt/db/follow.py
@@ -2,6 +2,7 @@ import logging
 
 from . import pg_connection
 from ._util import closing, table_exists
+from ._adapter import determine_keep_history
 
 logger = logging.getLogger(__name__)
 
@@ -75,13 +76,7 @@ class Updates:
     def __iter__(self):
         with closing(pg_connection(self.dsn)) as conn:
             with closing(conn.cursor()) as cursor:
-                keep_history = self.keep_history
-                if keep_history is None:
-                    cursor.execute(
-                        "select 1 from pg_catalog.pg_class "
-                        "where relname = 'current_object'")
-                    keep_history = bool(list(cursor))
-
+                keep_history = determine_keep_history(cursor, self.keep_history)
                 if keep_history:
                     self._query = self._query.replace(
                         'object_state s',

--- a/src/newt/db/follow.py
+++ b/src/newt/db/follow.py
@@ -77,6 +77,7 @@ class Updates:
         with closing(pg_connection(self.dsn)) as conn:
             with closing(conn.cursor()) as cursor:
                 keep_history = determine_keep_history(cursor, self.keep_history)
+
                 if keep_history:
                     self._query = self._query.replace(
                         'object_state s',

--- a/src/newt/db/jsonpickle.py
+++ b/src/newt/db/jsonpickle.py
@@ -5,6 +5,7 @@ indexing, querying and reporting in external systems like Postgres and
 Elasticsearch.
 """
 import binascii
+from six import BytesIO
 from six.moves import copyreg
 import _codecs
 import datetime
@@ -208,7 +209,7 @@ class JsonUnpickler:
 
     def set_pickle(self, pickle):
         self.pickle = pickle
-        self.ops = pickletools.genops(pickle)
+        self.ops = pickletools.genops(BytesIO(pickle))
 
     def load(self, **json_args):
         for op, arg, pos in self.ops:

--- a/src/newt/db/tests/base.py
+++ b/src/newt/db/tests/base.py
@@ -1,8 +1,11 @@
 import gc
 import sys
+import unittest
+
 PYPY = hasattr(sys, 'pypy_version_info')
 
 from .. import pg_connection
+from .._util import closing
 
 class DBSetup(object):
 
@@ -24,6 +27,11 @@ class DBSetup(object):
             super(DBSetup, self).setUp()
 
     def drop_db(self):
+        self.base_cursor.execute(
+            """
+            select pg_terminate_backend(pid) from pg_stat_activity
+            where datname = %s
+            """, (self.dbname,))
         self.base_cursor.execute('drop database if exists ' + self.dbname)
 
     def tearDown(self):
@@ -40,3 +48,6 @@ class DBSetup(object):
         self.drop_db()
         self.base_cursor.close()
         self.base_conn.close()
+
+class TestCase(DBSetup, unittest.TestCase):
+    pass

--- a/src/newt/db/tests/base.py
+++ b/src/newt/db/tests/base.py
@@ -1,7 +1,8 @@
-from relstorage.adapters.postgresql import adapter
 import gc
 import sys
 PYPY = hasattr(sys, 'pypy_version_info')
+
+from .. import pg_connection
 
 class DBSetup(object):
 
@@ -13,7 +14,7 @@ class DBSetup(object):
 
     def setUp(self, call_super=True):
         self.dbname = self.__class__.__name__.lower() + '_newt_test_database'
-        self.base_conn = adapter.select_driver().connect('')
+        self.base_conn = pg_connection('')
         self.base_conn.autocommit = True
         self.base_cursor = self.base_conn.cursor()
         self.drop_db()

--- a/src/newt/db/tests/testadapter.py
+++ b/src/newt/db/tests/testadapter.py
@@ -114,7 +114,7 @@ class AdapterTests(DBSetup, unittest.TestCase):
         pg_conn = select_driver().connect(self.dsn)
         cursor = pg_conn.cursor()
         cursor.execute(
-            "select 1 from pg_catalog.pg_trigger "
+            "select from pg_catalog.pg_trigger "
             "where tgname = 'newt_delete_on_state_delete_trigger'")
         self.assertEqual([], list(cursor))
         cursor.execute("""

--- a/src/newt/db/tests/testadapter.py
+++ b/src/newt/db/tests/testadapter.py
@@ -1,7 +1,6 @@
 import persistent.mapping
 import os
 import pickle
-from relstorage._compat import db_binary_to_bytes
 import relstorage.tests
 from relstorage.tests import hftestbase
 from relstorage.tests import hptestbase
@@ -30,14 +29,14 @@ class AdapterTests(DBSetup, unittest.TestCase):
             from newt where zoid = %s""",
             u64(o._p_oid))
         self.assertEqual(class_name, 'newt.db._object.Object')
-        self.assertEqual(pickle.loads(db_binary_to_bytes(ghost_pickle)), Object)
+        self.assertEqual(pickle.loads(ghost_pickle), Object)
         self.assertEqual(state, {'a': 1})
 
         [(class_name, ghost_pickle, state)] = conn.query_data("""\
             select class_name, ghost_pickle, state
             from newt where zoid = 0""")
         self.assertEqual(class_name, 'persistent.mapping.PersistentMapping')
-        self.assertEqual(pickle.loads(db_binary_to_bytes(ghost_pickle)),
+        self.assertEqual(pickle.loads(ghost_pickle),
                          persistent.mapping.PersistentMapping)
         self.assertEqual(
             state,

--- a/src/newt/db/tests/testdocs.py
+++ b/src/newt/db/tests/testdocs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import doctest
 import unittest
@@ -7,7 +8,11 @@ import manuel.testing
 from zope.testing import setupstack
 
 import newt
+from ..follow import updates as follow_updates
 from .base import DBSetup
+
+def finite_updates(conn, end_tid=1<<63, **kw):
+    return follow_updates(conn, end_tid=end_tid, **kw)
 
 def setUp(test):
     dbsetup = DBSetup()
@@ -15,7 +20,10 @@ def setUp(test):
     setupstack.register(test, dbsetup.tearDown)
     test.globs.update(
         dsn = dbsetup.dsn,
+        print_ = print,
         )
+
+    setupstack.mock(test, 'newt.db.follow.updates', side_effect=finite_updates)
 
 def test_suite():
     d = os.path.dirname
@@ -30,6 +38,7 @@ def test_suite():
             p('fine-print'),
             p('getting-started'),
             p('topics', 'text-configuration'),
+            p('topics', 'following'),
             setUp=setUp, tearDown=setupstack.tearDown,
             )
 

--- a/src/newt/db/tests/testfollow.py
+++ b/src/newt/db/tests/testfollow.py
@@ -12,7 +12,6 @@ class FollowTests(base.DBSetup, unittest.TestCase):
         self.conn = pg_connection(self.dsn)
         self.conn.autocommit = True
         self.cursor = self.conn.cursor()
-        self.mogrify = self.cursor.mogrify
         self.ex = self.cursor.execute
         if self.history_preserving:
             self.ex("create table if not exists object_state"
@@ -27,6 +26,9 @@ class FollowTests(base.DBSetup, unittest.TestCase):
         self.cursor.close()
         self.conn.close()
         super(FollowTests, self).tearDown()
+
+    def mogrify(self, *args):
+        return self.cursor.mogrify(*args).decode('ascii')
 
     def store(self, tid, *oids):
         svalues = ", ".join(self.mogrify("(%s, %s, 'some data')", (oid, tid))

--- a/src/newt/db/tests/testfollow.py
+++ b/src/newt/db/tests/testfollow.py
@@ -1,0 +1,75 @@
+import psycopg2
+import unittest
+
+from . import base
+
+class FollowTests(base.DBSetup, unittest.TestCase):
+
+    def setUp(self):
+        super(FollowTests, self).setUp()
+        self.conn = psycopg2.connect(self.dsn)
+        self.conn.autocommit = True
+        self.cursor = self.conn.cursor()
+        self.ex = self.cursor.execute
+        self.ex("create table if not exists object_state"
+                " (zoid bigint primary key, tid bigint, state bytea)")
+
+    def tearDown(self):
+        self.conn.close()
+        super(FollowTests, self).tearDown()
+
+    def store(self, tid, oid):
+        self.ex("insert into object_state values(%s, %s, 'some data')"
+                " on conflict (zoid)"
+                " do update set tid=excluded.tid, state=excluded.state",
+                (oid, tid))
+
+    def test_non_empty_generator(self):
+        from ..follow import non_empty_generator
+        self.assertEqual(non_empty_generator(iter(())), None)
+        self.assertEqual(list(non_empty_generator(iter((1, 2, 3)))), [1, 2, 3])
+
+    def test_update_iterator_batching(self):
+        t = 0
+        for i in range(99):
+            if i%7 == 0:
+                t += 1
+            self.store(t, i)
+        from ..follow import updates
+        conn = psycopg2.connect(self.conn.dsn)
+        self.assertEqual(
+            [[int(r[1]) for r in b]
+             for b in updates(conn, end_tid=99, batch_limit=20)
+             ],
+            [list(range(0, 21)),
+             list(range(21, 42)),
+             list(range(42, 63)),
+             list(range(63, 84)),
+             list(range(84, 99)),
+             ])
+
+        self.assertEqual(
+            [[int(r[1]) for r in b]
+             for b in updates(conn, start_tid=2, end_tid=4)
+             ],
+            [list(range(14, 28))],
+            )
+
+    def test_update_iterator_follow(self):
+        conn = psycopg2.connect(self.conn.dsn)
+        self.store(1, 1)
+        self.store(1, 2)
+        from ..follow import updates
+        it = iter(updates(conn))
+        self.assertEqual([(1, 1), (1, 2)],
+                         [(int(r[0]), int(r[1])) for r in next(it)])
+        self.store(2, 3)
+        self.store(2, 4)
+        self.assertEqual([(2, 3), (2, 4)],
+                         [(int(r[0]), int(r[1])) for r in next(it)])
+        self.store(3, 5)
+        self.store(3, 6)
+        self.store(4, 7)
+        self.store(4, 8)
+        self.assertEqual([(3, 5), (3, 6), (4, 7), (4, 8)],
+                         [(int(r[0]), int(r[1])) for r in next(it)])

--- a/src/newt/db/tests/testfollow.py
+++ b/src/newt/db/tests/testfollow.py
@@ -5,24 +5,45 @@ from . import base
 
 class FollowTests(base.DBSetup, unittest.TestCase):
 
+    history_preserving = False
+
     def setUp(self):
         super(FollowTests, self).setUp()
         self.conn = psycopg2.connect(self.dsn)
         self.conn.autocommit = True
         self.cursor = self.conn.cursor()
+        self.mogrify = self.cursor.mogrify
         self.ex = self.cursor.execute
-        self.ex("create table if not exists object_state"
-                " (zoid bigint primary key, tid bigint, state bytea)")
+        if self.history_preserving:
+            self.ex("create table if not exists object_state"
+                    " (zoid bigint, tid bigint, state bytea)")
+            self.ex("create table if not exists current_object"
+                    " (zoid bigint primary key, tid bigint)")
+        else:
+            self.ex("create table if not exists object_state"
+                    " (zoid bigint primary key, tid bigint, state bytea)")
 
     def tearDown(self):
         self.conn.close()
         super(FollowTests, self).tearDown()
 
-    def store(self, tid, oid):
-        self.ex("insert into object_state values(%s, %s, 'some data')"
-                " on conflict (zoid)"
-                " do update set tid=excluded.tid, state=excluded.state",
-                (oid, tid))
+    def store(self, tid, *oids):
+        svalues = ", ".join(self.mogrify("(%s, %s, 'some data')", (oid, tid))
+                            for oid in oids)
+        cvalues = ", ".join(self.mogrify("(%s, %s)", (oid, tid))
+                            for oid in oids)
+        if self.history_preserving:
+            self.ex("insert into object_state values {}".format(svalues))
+            self.ex("""\
+            insert into current_object values {}
+            on conflict (zoid) do update set tid=excluded.tid
+            """.format(cvalues))
+        else:
+            self.ex("""
+            insert into object_state values {}
+            on conflict (zoid)
+            do update set tid=excluded.tid, state=excluded.state
+            """.format(svalues))
 
     def test_non_empty_generator(self):
         from ..follow import non_empty_generator
@@ -31,45 +52,74 @@ class FollowTests(base.DBSetup, unittest.TestCase):
 
     def test_update_iterator_batching(self):
         t = 0
-        for i in range(99):
-            if i%7 == 0:
-                t += 1
-            self.store(t, i)
+        for i in range(0, 99, 7):
+            t += 1
+            self.store(t, *range(i, i+7))
+        t = 20
+        for i in range(0, 99, 7):
+            t += 1
+            self.store(t, *range(i, i+7))
         from ..follow import updates
         conn = psycopg2.connect(self.conn.dsn)
         self.assertEqual(
             [[int(r[1]) for r in b]
-             for b in updates(conn, end_tid=99, batch_limit=20)
+             for b in updates(conn, end_tid=999, batch_limit=20)
              ],
             [list(range(0, 21)),
              list(range(21, 42)),
              list(range(42, 63)),
              list(range(63, 84)),
-             list(range(84, 99)),
+             list(range(84, 105)),
              ])
 
         self.assertEqual(
             [[int(r[1]) for r in b]
-             for b in updates(conn, start_tid=2, end_tid=4)
+             for b in updates(conn, start_tid=22, end_tid=24)
              ],
             [list(range(14, 28))],
             )
 
-    def test_update_iterator_follow(self):
+    def test_update_iterator_follow(self, poll_timeout=99):
         conn = psycopg2.connect(self.conn.dsn)
-        self.store(1, 1)
-        self.store(1, 2)
+        self.store(1, 1, 2)
+        self.store(2, 1, 2)
         from ..follow import updates
-        it = iter(updates(conn))
-        self.assertEqual([(1, 1), (1, 2)],
-                         [(int(r[0]), int(r[1])) for r in next(it)])
-        self.store(2, 3)
-        self.store(2, 4)
-        self.assertEqual([(2, 3), (2, 4)],
-                         [(int(r[0]), int(r[1])) for r in next(it)])
-        self.store(3, 5)
-        self.store(3, 6)
-        self.store(4, 7)
-        self.store(4, 8)
-        self.assertEqual([(3, 5), (3, 6), (4, 7), (4, 8)],
-                         [(int(r[0]), int(r[1])) for r in next(it)])
+
+        import threading
+
+        data = []
+        def collect():
+            for batch in updates(conn, poll_timeout=poll_timeout):
+                data.append([(int(r[0]), int(r[1])) for r in batch])
+
+        thread = threading.Thread(target=collect)
+        thread.setDaemon(True)
+        thread.start()
+
+        from zope.testing.wait import wait
+        def wait_equal(e, g):
+            try:
+                wait(lambda : e==g)
+            except Exception:
+                raise
+
+        try:
+            wait_equal([[(2, 1), (2, 2)]], data); del data[:]
+            self.store(3, 3, 4)
+            wait_equal([[(3, 3), (3, 4)]], data); del data[:]
+            self.store(4, 5, 6)
+            wait_equal([[(4, 5), (4, 6)]], data); del data[:]
+            self.store(5, 7, 8)
+            wait_equal([[(5, 7), (5, 8)]], data); del data[:]
+            self.store(6, 5, 8)
+            wait_equal([[(6, 5), (6, 8)]], data); del data[:]
+        finally:
+            self.ex("notify newt_object_state_changed, 'STOP'")
+            thread.join(9)
+
+    def test_update_iterator_follow_no_timeout(self):
+        self.test_update_iterator_follow(None)
+
+class FollowTestsHP(FollowTests):
+
+    history_preserving = True

--- a/src/newt/db/tests/testfollow.py
+++ b/src/newt/db/tests/testfollow.py
@@ -1,4 +1,5 @@
 import unittest
+from zope.testing.wait import wait
 
 from .. import pg_connection
 from . import base
@@ -81,6 +82,12 @@ class FollowTests(base.DBSetup, unittest.TestCase):
             [list(range(14, 28))],
             )
 
+    def wait_equal(self, expect, got):
+        try:
+            wait(lambda : expect == got)
+        except Exception:
+            self.assertEqual(expect, got)
+
     def test_update_iterator_follow(self, poll_timeout=99):
         self.store(1, 1, 2)
         self.store(2, 1, 2)
@@ -98,13 +105,7 @@ class FollowTests(base.DBSetup, unittest.TestCase):
         thread.setDaemon(True)
         thread.start()
 
-        from zope.testing.wait import wait
-        def wait_equal(e, g):
-            try:
-                wait(lambda : e==g)
-            except Exception:
-                raise
-
+        wait_equal = self.wait_equal
         try:
             wait_equal([[(2, 1), (2, 2)]], data); del data[:]
             self.store(3, 3, 4)

--- a/src/newt/db/tests/testjsonpickle.py
+++ b/src/newt/db/tests/testjsonpickle.py
@@ -388,7 +388,7 @@ class JsonUnpicklerDBTests(unittest.TestCase):
         self.assertEqual('persistent.mapping.PersistentMapping', class_name)
         self.assertEqual('{"data": {}}', state)
         self.assertTrue(p.startswith(ghost_pickle) and
-                        ghost_pickle[-1] == '.' and
+                        ghost_pickle[-1:] == b'.' and
                         b'persistent.mapping' in ghost_pickle)
 
         # custon skip_class
@@ -409,7 +409,7 @@ class JsonUnpicklerDBTests(unittest.TestCase):
         self.assertEqual(handler.records, [])
         self.assertEqual((None, None, None), jsonifier('foo', b'badness'))
         self.assertEqual(
-            [r.getMessage() for r in handler.records],
+            [r.getMessage().replace("b'", "'") for r in handler.records],
             ["Failed pickle load, oid: 'foo', pickle starts: 'badness'"])
 
         handler.uninstall()

--- a/src/newt/db/tests/testjsonpickle.py
+++ b/src/newt/db/tests/testjsonpickle.py
@@ -376,3 +376,40 @@ class JsonUnpicklerDBTests(unittest.TestCase):
         _ = self.load()
         _ = self.load()
 
+    def test_jsonifier(self):
+        from zope.testing.loggingsupport import InstalledHandler
+        handler = InstalledHandler('newt.db.jsonpickle')
+        from ..jsonpickle import Jsonifier
+
+        jsonifier = Jsonifier()
+
+        p, tid = self.conn._storage.load(z64)
+        class_name, ghost_pickle, state = jsonifier('0', p)
+        self.assertEqual('persistent.mapping.PersistentMapping', class_name)
+        self.assertEqual('{"data": {}}', state)
+        self.assertTrue(p.startswith(ghost_pickle) and
+                        ghost_pickle[-1] == '.' and
+                        b'persistent.mapping' in ghost_pickle)
+
+        # custon skip_class
+        jsonifier2 = Jsonifier(skip_class=lambda c: 1)
+        self.assertEqual((None, None, None), jsonifier2('0', p))
+
+        # empty records are skipped:
+        self.assertEqual((None, None, None), jsonifier('0', ''))
+
+        # BTrees are skipped by default
+        from BTrees.OOBTree import BTree
+        self.root.x = BTree()
+        self.conn.transaction_manager.commit()
+        p, tid = self.conn._storage.load(self.root.x._p_oid)
+        self.assertEqual((None, None, None), jsonifier('0', p))
+
+        # errors are logged, and return Nones:
+        self.assertEqual(handler.records, [])
+        self.assertEqual((None, None, None), jsonifier('foo', b'badness'))
+        self.assertEqual(
+            [r.getMessage() for r in handler.records],
+            ["Failed pickle load, oid: 'foo', pickle starts: 'badness'"])
+
+        handler.uninstall()

--- a/src/newt/db/tests/testupdater.py
+++ b/src/newt/db/tests/testupdater.py
@@ -1,0 +1,127 @@
+import relstorage.adapters.postgresql
+import threading
+import ZODB.serialize
+from zope.testing.wait import wait
+
+from .. import follow
+from .. import Object
+from .. import updater
+
+from . import base
+
+class UpdaterTests(base.TestCase):
+
+    def setUp(self):
+        super(UpdaterTests, self).setUp()
+        driver = relstorage.adapters.postgresql.select_driver()
+        self.conn = driver.connect(self.dsn)
+        self.Binary = driver.Binary
+        self.conn.autocommit = True
+        self.cursor = self.conn.cursor()
+        self.mogrify = self.cursor.mogrify
+        self.ex = self.cursor.execute
+        self.ex("create table if not exists object_state"
+                " (zoid bigint primary key, tid bigint, state bytea)")
+
+        # Avoid a race. The first time this is called, a table gets
+        # created after trying and failing a select.  The updater
+        # calls this on startup.  We also call this to monitor
+        # progress.  We can end up with a race when this happens at
+        # the same time. We could add a lock, in get_progress_tid, but
+        # this only seems to be an issue in tests.
+        self.assertEqual(self.last_tid(), -1)
+
+    def tearDown(self):
+        self.stop_updater()
+        self.cursor.close()
+        self.conn.close()
+        super(UpdaterTests, self).tearDown()
+
+
+    def store_obs(self, tid, *obs):
+        writer = ZODB.serialize.ObjectWriter()
+        values = ', '.join(
+            self.mogrify("(%s, %s, %s)",
+                         (oid, tid, self.Binary(writer.serialize(ob)))
+                         ).decode('ascii')
+            for (oid, ob) in obs
+            )
+        self.ex("insert into object_state(zoid, tid, state) values %s"
+                " on conflict (zoid)"
+                " do update set tid=excluded.tid, state=excluded.state"
+                % values)
+
+    thread = None
+    def start_updater(self, *args):
+        thread = threading.Thread(
+            target=updater.main,
+            args=([self.dsn, '-t1', '-m200'] + list(args),))
+        thread.daemon = True
+        thread.start()
+        self.thread = thread
+
+    def stop_updater(self):
+        if self.thread is not None:
+            for i in range(3):
+                follow.stop_updates(self.conn)
+                self.thread.join(.2)
+                if not self.thread.isAlive():
+                    self.thread = None
+                    return
+
+    def drop_trigger(self):
+        self.ex("drop trigger newt_trigger_notify_object_state_changed"
+                " on object_state")
+
+    def last_tid(self, expect=None):
+        tid = follow.get_progress_tid(self.conn, updater.__name__)
+        if expect is not None:
+            return expect == tid
+        else:
+            return tid
+
+    def wait_tid(self, tid):
+        wait((lambda : self.last_tid(tid)), 9, message="waiting for %s" % tid)
+
+    def search(self, where):
+        self.ex("select zoid from newt where %s" % where)
+        return list(self.cursor.fetchall())
+
+    def test_basic(self):
+        self.store_obs(1, (1, Object(a=1)), (2, Object(a=2)))
+        self.store_obs(2, (1, Object(a=1, b=1)), (2, Object(a=2, b=2)))
+
+        self.start_updater()
+        self.wait_tid(2)
+        self.store_obs(3, (2, Object(a=3, b=3)))
+        self.wait_tid(3)
+        self.store_obs(4, (2, Object(a=4, b=4)))
+        self.wait_tid(4)
+        self.stop_updater()
+        self.store_obs(5, (3, Object(n=3)))
+        self.start_updater()
+        self.wait_tid(5)
+
+        # Make sure data were stored correctly:
+        self.assertEqual(self.search("""state @> '{"b": 1}'::jsonb"""),
+                         [(1,)])
+        self.assertEqual(self.search("""state @> '{"b": 4}'::jsonb"""),
+                         [(2,)])
+        self.assertEqual(self.search("""state @> '{"n": 3}'::jsonb"""),
+                         [(3,)])
+
+    def test_skip_Uninteresting(self):
+        import BTrees.OOBTree
+        import ZODB.blob
+        self.start_updater()
+        self.store_obs(1, (1, BTrees.OOBTree.BTree()))
+        self.store_obs(2, (2, ZODB.blob.Blob()))
+        self.wait_tid(2)
+        self.ex("select zoid from newt")
+        self.assertEqual(list(self.cursor), [])
+        self.store_obs(3, (1, BTrees.OOBTree.BTree()))
+        self.store_obs(4, (2, ZODB.blob.Blob()))
+        self.store_obs(5, (3, Object(n=1)))
+        self.wait_tid(5)
+        self.ex("select zoid from newt")
+        self.assertEqual([int(*r) for r in self.cursor], [3])

--- a/src/newt/db/tests/testupdater.py
+++ b/src/newt/db/tests/testupdater.py
@@ -228,7 +228,8 @@ class UpdaterTests(base.TestCase):
         # Because the progress table doesn't exist yet, we get an error.
         import mock
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(2, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual('Updater has not run\n', ''.join(writes))
 
@@ -241,7 +242,8 @@ class UpdaterTests(base.TestCase):
 
         # So we're OK.
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(0, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual('No transactions\n', ''.join(writes))
 
@@ -254,7 +256,8 @@ class UpdaterTests(base.TestCase):
         tid = make_tid(2017, 1, 2, 3, 4, 5.6)
         follow.set_progress_tid(self.conn, updater.__name__, tid)
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(2, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual('Updater saw data but there was None\n',
                              ''.join(writes))
@@ -263,7 +266,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__, -1)
         self.store_obs(tid, (1, Object(a=1)), (2, Object(a=2)))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(2, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("Updater hasn't done anything\n",
                              ''.join(writes))
@@ -272,7 +276,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__,
                                 make_tid(2017, 1, 2, 3, 4, 5.7))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(2, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("Updater is ahead\n",
                              ''.join(writes))
@@ -281,7 +286,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__,
                                 make_tid(2017, 1, 2, 3, 4, 5.6))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(0, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("OK | 0.000\n", ''.join(writes))
             # Oh look! Metric!
@@ -290,7 +296,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__,
                                 make_tid(2017, 1, 2, 3, 4, 5.5))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(0, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("OK | 0.100\n", ''.join(writes))
 
@@ -298,7 +305,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__,
                                 make_tid(2017, 1, 2, 3, 4, 4.5))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(1, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("Updater is behind | 1.100\n", ''.join(writes))
 
@@ -306,7 +314,8 @@ class UpdaterTests(base.TestCase):
         follow.set_progress_tid(self.conn, updater.__name__,
                                 make_tid(2017, 1, 2, 3, 2, 4.5))
         writes = []
-        with mock.patch('sys.stdout.write', side_effect=writes.append):
+        with mock.patch('sys.stdout') as stdout:
+            stdout.write.side_effect=writes.append
             self.assertEqual(2, updater.main([self.dsn, '--nagios', '1,99']))
             self.assertEqual("Updater is too far behind | 121.100\n",
                              ''.join(writes))

--- a/src/newt/db/tests/testupdater.py
+++ b/src/newt/db/tests/testupdater.py
@@ -50,10 +50,12 @@ class UpdaterTests(base.TestCase):
                          ).decode('ascii')
             for (oid, ob) in obs
             )
+        self.ex("begin")
+        self.ex("delete from object_state where zoid = any(%s)",
+                ([oid for oid, ob in obs], ))
         self.ex("insert into object_state(zoid, tid, state) values %s"
-                " on conflict (zoid)"
-                " do update set tid=excluded.tid, state=excluded.state"
                 % values)
+        self.ex("commit")
 
     thread = None
     def start_updater(self, *args):

--- a/src/newt/db/updater.py
+++ b/src/newt/db/updater.py
@@ -103,8 +103,8 @@ def main(args=None):
         with closing(conn.cursor()) as cursor:
             tid = follow.get_progress_tid(conn, __name__)
             if tid < 0 and not table_exists(conn, 'newt'):
-                from ._adapter import create_newt
-                create_newt(cursor)
+                from ._adapter import _newt_ddl
+                cursor.execute(_newt_ddl)
             conn.commit()
             if options.redo:
                 start_tid = -1

--- a/src/newt/db/updater.py
+++ b/src/newt/db/updater.py
@@ -103,8 +103,8 @@ def main(args=None):
         with closing(conn.cursor()) as cursor:
             tid = follow.get_progress_tid(conn, __name__)
             if tid < 0 and not table_exists(conn, 'newt'):
-                from ._adapter import newt_ddl
-                cursor.execute(newt_ddl)
+                from ._adapter import create_newt
+                create_newt(cursor)
             conn.commit()
             if options.redo:
                 start_tid = -1

--- a/src/newt/db/updater.py
+++ b/src/newt/db/updater.py
@@ -102,7 +102,7 @@ def main(args=None):
     with closing(pg_connection(dsn)) as conn:
         with closing(conn.cursor()) as cursor:
             tid = follow.get_progress_tid(conn, __name__)
-            if tid < 0 and not table_exists(conn, 'newt'):
+            if tid < 0 and not table_exists(cursor, 'newt'):
                 from ._adapter import _newt_ddl
                 cursor.execute(_newt_ddl)
             conn.commit()

--- a/src/newt/db/updater.py
+++ b/src/newt/db/updater.py
@@ -1,0 +1,130 @@
+from __future__ import print_function
+"""Updates database json representation
+"""
+
+import argparse
+import itertools
+import logging
+import relstorage.adapters.postgresql
+import relstorage.options
+
+from . import pg_connection
+from . import follow
+from .jsonpickle import Jsonifier
+from ._util import closing, table_exists
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('connection_string', help='Postgresql connection string')
+parser.add_argument('-t', '--poll-timeout', type=int, default=30,
+                    help='Change-poll timeout, in seconds')
+parser.add_argument('-m', '--transaction-size-limit', type=int, default=100000,
+                    help='Transaction size limit (aproximate)')
+parser.add_argument(
+    '-l', '--logging-configuration', default='info',
+    help='Logging configuration file path, or a logging level name')
+
+parser.add_argument(
+    '-d', '--driver', default='auto',
+    help='Provide an explicit Postgres driver name (e.g. psycopg2)')
+
+parser.add_argument(
+    '--redo', action='store_true',
+    help="""\
+Redo updates
+
+Rather than processing records written before the current tid (in
+object_json_tid), process records writen up through the current tid
+and stop.
+
+This is used to update records after changes to data
+transformations. It should be run *after* restarting the regulsr
+updater.
+""")
+
+insert_sql = """
+insert into newt (zoid, class_name, ghost_pickle, state)
+values %s
+on conflict (zoid)
+do update set class_name   = excluded.class_name,
+              ghost_pickle = excluded.ghost_pickle,
+              state        = excluded.state
+"""
+
+def update_newt(conn, cursor, jsonifier, Binary, batch):
+    ex = cursor.execute
+    mogrify = cursor.mogrify
+
+    tid = None
+    while True:
+        data = list(itertools.islice(batch, 0, 100))
+        if not data:
+            break
+        tid = data[-1][0]
+
+        # Convert, filtering out null conversions (uninteresting classes)
+        to_save = []
+        for tid, zoid, state in data:
+            class_name, ghost_pickle, state = jsonifier((tid, zoid), state)
+            if state is not None:
+                to_save.append((zoid, class_name, Binary(ghost_pickle), state))
+
+        if to_save:
+            ex(insert_sql %
+               ', '.join(mogrify('(%s, %s, %s, %s)', d).decode('ascii')
+                         for d in to_save)
+               )
+
+    if tid is not None:
+        follow.set_progress_tid(conn, __name__, tid)
+
+    conn.commit()
+
+
+logging_levels = 'DEBUG INFO WARNING ERROR CRITICAL'.split()
+
+def main(args=None):
+    options = parser.parse_args(args)
+
+    if options.logging_configuration.upper() in logging_levels:
+        logging.basicConfig(level=options.logging_configuration.upper())
+    else:
+        with open(options.logging_configuration) as f:
+            from ZConfig import configureLoggers
+            configureLoggers(f.read())
+
+    jsonifier = Jsonifier()
+    driver = relstorage.adapters.postgresql.select_driver(
+        relstorage.options.Options(driver=options.driver))
+    Binary = driver.Binary
+    conn, cursor = driver.connect_with_isolation(
+        driver.ISOLATION_LEVEL_SERIALIZABLE,
+        options.connection_string)
+    with closing(conn):
+        with closing(cursor):
+            tid = follow.get_progress_tid(conn, __name__)
+            if tid < 0 and not table_exists(conn, 'newt'):
+                from ._adapter import newt_ddl
+                cursor.execute(newt_ddl)
+            conn.commit()
+            if options.redo:
+                start_tid = -1
+                end_tid = tid
+                logger.info("Redoing through", tid)
+            else:
+                logger.info("Starting updater at %s", tid)
+                start_tid = tid
+                end_tid = None
+
+            for batch in follow.updates(
+                conn,
+                start_tid=start_tid,
+                end_tid=end_tid,
+                batch_limit=options.transaction_size_limit,
+                poll_timeout=options.poll_timeout,
+                ):
+                update_newt(conn, cursor, jsonifier, Binary, batch)
+
+if __name__ == '__main__':
+    main()

--- a/src/newt/db/updater.py
+++ b/src/newt/db/updater.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument('connection_string', help='Postgresql connection string')
-parser.add_argument('-t', '--poll-timeout', type=int, default=30,
+parser.add_argument('-t', '--poll-timeout', type=int, default=300,
                     help='Change-poll timeout, in seconds')
 parser.add_argument('-m', '--transaction-size-limit', type=int, default=100000,
                     help='Transaction size limit (aproximate)')

--- a/todo.rst
+++ b/todo.rst
@@ -22,3 +22,4 @@ Medium priorities:
 
 - Async support
 
+- handle transformed data in the jsonifier


### PR DESCRIPTION
This PR, which grew  a bit bigger than I would have prefered, provides:

- Asynchronous update of newt JSON data

  - For cases where there are lots of indexes or where write speed is critical.

  - To add newtousness to existing RelStorage/PostgreSQL applications.

- Provides an API that can be used outside of newt to update external indexes and other representations, such as Elasticsearch.