### PR TITLE
Document and fix serialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,22 @@
 Changes
 =======
 
-0.3.1 (unreleased)
+0.4.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Serialization of persistent object references and intra-record
+  references (used only when there are cycles) was simplified and made
+  easier to use.
 
+  Note: The change to intra-object references is backward
+  incompatible, however, intra-record cycles, and thus the use of
+  intra-record references, are extremely rare and it isn't thought
+  that this change will affect anyone.  If this causes problems,
+  please `create an issue <https://github.com/newtdb/db/issues/new>`_.
+
+  The change to persistent references was made in a backward-compatible
+  way, but the backward compatibility support will be dropped in Newt
+  DB version 1.
 
 0.3.0 (2017-02-10)
 ==================

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -10,6 +10,7 @@ Newt DB Topics
    admin
    schemas
    for-zodb-users
+   serialization
    data-transformation
    updater
    following

--- a/doc/topics/serialization.rst
+++ b/doc/topics/serialization.rst
@@ -1,0 +1,194 @@
+=======================
+JSON Serialization
+=======================
+
+This topic explains some details about how data are serialized to
+JSON, beyond the behavior of the standard Python `json module
+<https://docs.python.org/3/library/json.html#module-json>`_.
+
+The first thing to note is that JSON serialization is lossy.  This is
+why Newt saves data in both `pickle
+<https://docs.python.org/3/library/pickle.html#data-stream-format>`_
+and JSON format.
+
+The serialization nevertheless preserves class information.
+
+The serialization, like pickle, supports cyclic data structures using a
+combination of persistent references and intra-record references.
+
+Non-persistent instances
+========================
+
+Non-persistent instances are converted to JSON objects with ``::``
+properties giving their dotted class names.  In the common case of
+objects with their instance dictionaries used as their pickled state,
+the object attributes become properties.
+
+So, for example, given a class ``MyClass`` in module ``mymodule``::
+
+  class MyClass:
+
+      def __init__(self, a, b):
+          self.a = a
+          self.b = b
+
+.. -> src
+
+    >>> exec(src)
+    >>> MyClass.__module__ = 'newt.db.tests'
+    >>> import newt.db.tests
+    >>> newt.db.tests.MyClass = MyClass
+    >>> i = MyClass(1, 2)
+
+The JSON serialization would look like:
+
+.. code-block:: json
+
+  {"::": "mymodule.MyClass", "a": 1, "b": 2}
+
+.. -> expect
+
+    >>> expect = expect.strip().replace('mymodule', MyClass.__module__)
+    >>> from newt.db.jsonpickle import dumps
+    >>> dumps(i, indent=None) == expect
+    True
+
+Non-dictionary state
+--------------------
+
+For instances with pickled state that's not a dictionary, a JSON
+object is created with a ``state`` property containing the serialized
+state and a ``::`` property with the dotted class name.
+
+New arguments
+-------------
+
+Objects that take arguments to their ``__new__`` method will have the
+arguments serialized in the ``::()`` property.
+
+Intra-object reference ids
+--------------------------
+
+If a record has cycles and an object in the record is referenced more
+than once, then the object will have an ``::id`` property who's value
+is an internal reference id.
+
+For objects like lists and sets, which aren't normally serialized as
+objects, when an object is referenced more than once, it's wrapped in
+a "shared" object with an ``::id`` property and a ``value`` property.
+
+Intra-record cycles
+===================
+
+Cyclic data structures are allowed within persistent object records,
+although they are **extremely rare**.  When there's a cycle, then objects
+that are referenced more than once:
+
+- have ``::id`` properties that assign them intra-record ids.
+
+  Objects like lists, who's state are not dictionary are wrapped in a
+  "shared" objects.
+
+- Are replaced with reference objects in all bit one of the
+  references.  Reference objects have a single property, ``::->``
+  giving the intra-record id of the object being referenced.
+
+Here's an example:
+
+  >>> from newt.db.tests.testjsonpickle import I
+  >>> i = I(a=1)
+  >>> d = dict(b=1)
+  >>> l = [i, i, d, d]
+  >>> l.append(l)
+
+The serialization of the list, ``l`` would be equivalent to:
+
+.. code-block:: json
+
+    {
+      "::": "shared",
+      "::id": 0,
+      "value": [
+        {
+          "::": "newt.db.tests.testjsonpickle.I",
+          "::id": 2,
+          "a": 1
+        },
+        {"::->": 2},
+        {
+          "::id": 5,
+          "b": 1
+        },
+        {"::->": 5},
+        {"::->": 0}
+      ]
+    }
+
+.. -> expect
+
+   >>> import json
+   >>> expect = json.loads(expect)
+   >>> json.loads(dumps(l)) == expect
+   True
+
+Intra-record references like these are difficult to work with, which
+is a good reason to avoid intra-record cycles.
+
+Persistent object
+=================
+
+Persistent objects are stored in 4 columns of the ``newt`` table:
+
+============  ======
+   Column      Type
+============  ======
+zoid          bigint
+class_name    text
+ghost_pickle  bytea
+state         jsonb
+============  ======
+
+The class name and state are separated and the state doesn't have a
+``::`` property containing the dotted class name.
+
+The ``ghost_pickle`` field contains the class name and ``__new__``
+arguments if necessary.  It's used to create new objects when searching.
+
+Persistent references
+---------------------
+
+When one persistent object references another persistent object, the
+reference is serialized with a reference object, having a property
+``::=>`` whose value is the object id of the referenced object
+[#prefchanged]_. For example, serialization of a sub-task object
+containing a reference to a parent task would be equivalent to:
+
+.. code-block:: json
+
+   {
+     "title": "Do something",
+     "parent": {"::=>": 42}
+   }
+
+Note that cycles among persistent objects are common and don't present
+any problems for serialization because persistent objects are
+serialized separately.
+
+Dates and times
+===============
+
+``datetime.date`` objects and ``datetime.datetime`` instances without
+time zones are converted strings using their ``isoformat`` methods.
+
+``datetime.datetime`` instances with time zones are serialized as
+objects with a ``::`` property of ``datetime``, a ``value`` property
+with their ISO formatted value, and a ``tz`` property containing a
+JSON serialization of their time zones.
+
+.. [#prefchanged] This is a change from versions of Newt before 0.4.0.
+   Earlier versions represented persistent references as objects with
+   a ``::`` property with the value ``persistent`` and an ``id``
+   property who's value is an integer object id or a list containing
+   an integer object id and a dotted class name.  The attributes will
+   be retained until Newt DB version 1, at which point they will no
+   longer be included.

--- a/src/newt/db/tests/testadapter.py
+++ b/src/newt/db/tests/testadapter.py
@@ -41,7 +41,7 @@ class AdapterTests(DBSetup, unittest.TestCase):
         self.assertEqual(
             state,
             {'data': {'x': {'id': [1, 'newt.db._object.Object'],
-                            '::': 'persistent'}}})
+                            '::': 'persistent', '::=>': 1}}})
 
     def test_basic(self):
         import newt.db

--- a/src/newt/db/tests/testdocs.py
+++ b/src/newt/db/tests/testdocs.py
@@ -5,6 +5,7 @@ import unittest
 import manuel.capture
 import manuel.doctest
 import manuel.testing
+from pprint import pprint
 from zope.testing import setupstack
 
 import newt
@@ -19,8 +20,9 @@ def setUp(test):
     dbsetup.setUp(False)
     setupstack.register(test, dbsetup.tearDown)
     test.globs.update(
-        dsn = dbsetup.dsn,
-        print_ = print,
+        dsn=dbsetup.dsn,
+        print_=print,
+        pprint=pprint,
         )
 
     setupstack.mock(test, 'newt.db.follow.updates', side_effect=finite_updates)
@@ -39,6 +41,7 @@ def test_suite():
             p('getting-started'),
             p('topics', 'text-configuration'),
             p('topics', 'following'),
+            p('topics', 'serialization'),
             p('topics', 'zodburi'),
             p('topics', 'data-transformation'),
             setUp=setUp, tearDown=setupstack.tearDown,

--- a/src/newt/db/tests/testjsonpickle.py
+++ b/src/newt/db/tests/testjsonpickle.py
@@ -24,13 +24,15 @@ import unittest
 import ZODB
 from ZODB.utils import z64, p64, maxtid
 
-from ..jsonpickle import JsonUnpickler
+from ..jsonpickle import JsonUnpickler, dumps
 
 class C(object):
-    pass
+    def __init__(self, **attrs):
+        self.__dict__.update(attrs)
 
 class I:
-    pass
+    def __init__(self, **attrs):
+        self.__dict__.update(attrs)
 
 class P(persistent.Persistent):
 
@@ -192,18 +194,17 @@ class JsonUnpicklerProtocol0Tests(unittest.TestCase):
         got = JsonUnpickler(pickle.dumps(data, self.proto)).load(sort_keys=True)
         self.assertEqual(
             got,
-            '{"::": "shared", "id": 0, "value":'
-            ' [1, 2, [3, {"::": "ref", "id": 0}]]}'
+            '{"::": "shared", "::id": 0, "value":'
+            ' [1, 2, [3, {"::->": 0}]]}'
             )
 
     def test_cyclic_object(self, cls=C):
         c = cls(); c.name = 'c'; c.c = c
         got = json.loads(JsonUnpickler(pickle.dumps(c, self.proto)).load())
-        self.assertEqual(got.pop('::id'), got['state']['c'].pop('id'))
+        self.assertEqual(got.pop('::id'), got['c'].pop('::->'))
         self.assertEqual(
             {"::": "newt.db.tests.testjsonpickle." + cls.__name__,
-             "state": {"c": {"::": "ref"},
-                       "name": "c"}},
+             "c": {}, "name": "c"},
             got)
 
     def test_cyclic_instance(self):
@@ -220,6 +221,15 @@ class JsonUnpicklerProtocol0Tests(unittest.TestCase):
         got = JsonUnpickler(pickle.dumps(data, self.proto)).load()
         self.assertEqual(got, '1.2')
 
+    def test_non_empty_instance(self):
+        i = I(a=1)
+        self.assertEqual('{"::": "newt.db.tests.testjsonpickle.I", "a": 1}',
+                         dumps(i, indent=None))
+        i = C(a=1)
+        self.assertEqual('{"::": "newt.db.tests.testjsonpickle.C", "a": 1}',
+                         dumps(i, indent=None))
+
+
 class TZ(datetime.tzinfo):
     pass
 
@@ -233,8 +243,10 @@ class JsonUnpicklerProtocol1Tests(JsonUnpicklerProtocol0Tests):
         got = JsonUnpickler(f.getvalue()).load(sort_keys=True)
         self.assertEqual(
             got,
-            '[{"::": "persistent", "id": 18446744073709551615},'
-            ' {"::": "persistent", "id": 18446744073709551615}]')
+            '[{"::": "persistent", "::=>": 18446744073709551615,'
+            ' "id": 18446744073709551615},'
+            ' {"::": "persistent", "::=>": 18446744073709551615,'
+            ' "id": 18446744073709551615}]')
 
     def test_dt_with_tz(self):
         data = datetime.datetime(1, 2, 3, 4, 5, 6, 7, TZ())
@@ -344,7 +356,7 @@ class JsonUnpicklerDBTests(unittest.TestCase):
                u'date': u'2001-02-03T00:00:00',
                u'delta': {u'::': u'datetime.timedelta',
                           u'::()': [1, 2, 3]},
-               u'first': {u'::': u'persistent',
+               u'first': {u'::': u'persistent', u'::=>': 1,
                           u'id': [1, u'persistent.mapping.PersistentMapping']},
                u'list': [1, 2, 3, u'root',
                          [0, 123456789, 1180591620717411303424, 1234.56789]],


### PR DESCRIPTION
This adds documentation and changes serialization:

  Serialization of persistent object references and intra-record
  references (used only when there are cycles) was simplified and made
  easier to use.

  Note: The change to intra-object references is backward
  incompatible, however, intra-record cycles, and thus the use of
  intra-record references, are extremely rare and it isn't thought
  that this change will affect anyone.  If this causes problems,
  please `create an issue <https://github.com/newtdb/db/issues/new>`_.

  The change to persistent references was made in a backward-compatible
  way, but the backward compatibility support will be dropped in Newt
  DB version 1.
