### PR TITLE
Various changes to make it cleaner for clients to do safe SQL generation with mogrify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 0.5.0 (unreleased)
 ==================
 
+- Connections have a new ``read_only_cursor`` method for obtaining a
+  `database cursor <http://initd.org/psycopg/docs/cursor.html>`_ for
+  selecting data and for using the `cursor's mogrify method
+  <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_.
+
 - The helpers for setting up full-text search indexes now accept a
   config argument to specify the name of a PostgreSQL full-text search
   configuration.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,10 @@ Changes
 0.5.0 (unreleased)
 ==================
 
-- Connections have a new ``read_only_cursor`` method for obtaining a
-  `database cursor <http://initd.org/psycopg/docs/cursor.html>`_ for
-  selecting data and for using the `cursor's mogrify method
+- The ``newt.db.search`` module has a new ``read_only_cursor``
+  function for obtaining a `database cursor
+  <http://initd.org/psycopg/docs/cursor.html>`_ for selecting data and
+  for using the `cursor's mogrify method
   <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_.
 
 - The helpers for setting up full-text search indexes now accept a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,18 @@ Changes
   config argument to specify the name of a PostgreSQL full-text search
   configuration.
 
+- The batch search methods (``search_batch``, and ``where_batch``) now
+  allow the arguments parameter to be omitted, which is useful when
+  substitutions have been be applied with a `cursor mogrify method
+  <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_ before
+  calling them.
+
+- The search methods (``search``, ``search_batch``, ``where`` and
+  ``where_batch``) now accept binary queries.  This is allow
+  substitutions to be applied with a `cursor mogrify method
+  <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_ before
+  calling them.
+
 
 0.4.0 (2017-03-25)
 ==================

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -17,7 +17,7 @@ newt.db module-level functions
 
 .. autoclass:: newt.db.Connection
    :members: where, search, where_batch, search_batch, query_data,
-             create_text_index_sql, create_text_index
+             create_text_index_sql, create_text_index, read_only_cursor
 
    .. method:: abort()
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -17,7 +17,7 @@ newt.db module-level functions
 
 .. autoclass:: newt.db.Connection
    :members: where, search, where_batch, search_batch, query_data,
-             create_text_index_sql, create_text_index, read_only_cursor
+             create_text_index_sql, create_text_index
 
    .. method:: abort()
 
@@ -35,7 +35,7 @@ newt.db.search module-level functions
 
 .. automodule:: newt.db.search
    :members: where, search, where_batch, search_batch, query_data,
-             create_text_index_sql, create_text_index
+             create_text_index_sql, create_text_index, read_only_cursor
 
 newt.db.follow module-level functions
 =====================================

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 name = 'newt.db'
 version = '0.4.1.dev0'
 
-install_requires = ['setuptools', 'RelStorage[postgresql]', 'six']
+install_requires = ['setuptools', 'RelStorage[postgresql] >=2', 'six']
 extras_require = dict(test=['manuel', 'mock', 'zope.testing', 'zc.zlibstorage'])
 
 entry_points = """

--- a/src/newt/db/_db.py
+++ b/src/newt/db/_db.py
@@ -79,19 +79,6 @@ class Connection:
         else:
             self._connection.commit(ignore)
 
-    def read_only_cursor(self):
-        """Get a database cursor for reading.
-
-        The returned `cursor
-        <http://initd.org/psycopg/docs/cursor.html>`_ can be used to
-        make PostgreSQL queries and to perform safe SQL generation
-        using the `cursor's mogrify method
-        <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_.
-
-        The caller must close the returned cursor after use.
-        """
-        return self._storage.ex_cursor()
-
 def _split_options(
     # DB options
     pool_size=7,

--- a/src/newt/db/_db.py
+++ b/src/newt/db/_db.py
@@ -52,7 +52,7 @@ class Connection:
         return _search.where(self, query_tail, *args, **kw)
     where.__doc__ = _search.where.__doc__
 
-    def where_batch(self, query_tail, args, batch_start, batch_size):
+    def where_batch(self, query_tail, args, batch_start, batch_size=None):
         return _search.where_batch(
             self, query_tail, args, batch_start, batch_size)
     where_batch.__doc__ = _search.where_batch.__doc__

--- a/src/newt/db/_db.py
+++ b/src/newt/db/_db.py
@@ -79,6 +79,19 @@ class Connection:
         else:
             self._connection.commit(ignore)
 
+    def read_only_cursor(self):
+        """Get a database cursor for reading.
+
+        The returned `cursor
+        <http://initd.org/psycopg/docs/cursor.html>`_ can be used to
+        make PostgreSQL queries and to perform safe SQL generation
+        using the `cursor's mogrify method
+        <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_.
+
+        The caller must close the returned cursor after use.
+        """
+        return self._storage.ex_cursor()
+
 def _split_options(
     # DB options
     pool_size=7,

--- a/src/newt/db/search.py
+++ b/src/newt/db/search.py
@@ -33,7 +33,7 @@ def search(conn, query, *args, **kw):
                             " not both")
         args = kw
     get = conn.ex_get
-    cursor = conn._storage.ex_cursor()
+    cursor = conn.read_only_cursor()
     try:
         cursor.execute((b"select zoid, ghost_pickle from (%s)_"
                         if isinstance(query, bytes) else
@@ -88,7 +88,7 @@ def search_batch(conn, query, args, batch_start, batch_size=None):
         """
         ) % (query, batch_start, batch_size)
     get = conn.ex_get
-    cursor = conn._storage.ex_cursor()
+    cursor = conn.read_only_cursor()
     try:
         cursor.execute(query, args)
         count = 0

--- a/src/newt/db/search.py
+++ b/src/newt/db/search.py
@@ -33,7 +33,7 @@ def search(conn, query, *args, **kw):
                             " not both")
         args = kw
     get = conn.ex_get
-    cursor = conn.read_only_cursor()
+    cursor = read_only_cursor(conn)
     try:
         cursor.execute((b"select zoid, ghost_pickle from (%s)_"
                         if isinstance(query, bytes) else
@@ -88,7 +88,7 @@ def search_batch(conn, query, args, batch_start, batch_size=None):
         """
         ) % (query, batch_start, batch_size)
     get = conn.ex_get
-    cursor = conn.read_only_cursor()
+    cursor = read_only_cursor(conn)
     try:
         cursor.execute(query, args)
         count = 0
@@ -306,3 +306,17 @@ def where_batch(conn, query_tail, args, batch_start, batch_size=None):
                          "select * from newt where ")
                         + query_tail,
                         args, batch_start, batch_size)
+
+
+def read_only_cursor(conn):
+    """Get a database cursor for reading.
+
+    The returned `cursor
+    <http://initd.org/psycopg/docs/cursor.html>`_ can be used to
+    make PostgreSQL queries and to perform safe SQL generation
+    using the `cursor's mogrify method
+    <http://initd.org/psycopg/docs/cursor.html#cursor.mogrify>`_.
+
+    The caller must close the returned cursor after use.
+    """
+    return conn._storage.ex_cursor()


### PR DESCRIPTION
- Provide an API for getting a cursor (to get at mogrify)

- Allow the search methods to take bytes, as generated by mogrify.

This will be needed by newt.qbe