### PR TITLE
- Fixed: When arguments are omitted, there were errors because

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changes
 0.5.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed: When arguments are omitted, there were errors because
+  psycopg2 was trying to do substitutions anyway and choking on ``%``
+  characters in ``like`` queries.
+
+- Fixed: Connection.search_batch didn't allow arguments to be omitted.
 
 
 0.5.0 (2017-03-30)

--- a/src/newt/db/_db.py
+++ b/src/newt/db/_db.py
@@ -30,7 +30,7 @@ class Connection:
         return _search.search(self, query, *args, **kw)
     search.__doc__ = _search.search.__doc__
 
-    def search_batch(self, query, args, batch_start, batch_size):
+    def search_batch(self, query, args, batch_start, batch_size=None):
         return _search.search_batch(self, query, args, batch_start, batch_size)
     search_batch.__doc__ = _search.search_batch.__doc__
 

--- a/src/newt/db/search.py
+++ b/src/newt/db/search.py
@@ -38,7 +38,7 @@ def search(conn, query, *args, **kw):
         cursor.execute(b"select zoid, ghost_pickle from (" + query + b")_"
                        if isinstance(query, bytes) else
                        "select zoid, ghost_pickle from (" + query + ")_",
-                       args or kw)
+                       args or None)
         return [get(p64(zoid), ghost_pickle) for (zoid, ghost_pickle) in cursor]
     finally:
         _try_to_close_cursor(cursor)
@@ -71,7 +71,7 @@ def search_batch(conn, query, args, batch_start, batch_size=None):
         if isinstance(args, int):
             batch_size = batch_start
             batch_start = args
-            args = ()
+            args = None
         else:
             raise AssertionError("Invalid batch size %r" % batch_size)
 
@@ -92,7 +92,7 @@ def search_batch(conn, query, args, batch_start, batch_size=None):
     get = conn.ex_get
     cursor = read_only_cursor(conn)
     try:
-        cursor.execute(query, args)
+        cursor.execute(query, args or None)
         count = 0
         result = []
         for zoid, ghost_pickle, count in cursor:

--- a/src/newt/db/tests/testsearch.py
+++ b/src/newt/db/tests/testsearch.py
@@ -98,6 +98,15 @@ class SearchTests(DBSetup, unittest.TestCase):
         self.assertEqual(total, 89)
         self.assertEqual(list(range(12, 32)), [o.i for o in batch])
 
+    def test_search_no_args_no_problem_w_percent(self):
+        self.assertEqual(
+            [],
+            list(self.conn.search("select * from newt where 'x' like 'y%'")))
+        self.assertEqual(
+            (0, []),
+            self.conn.search_batch(
+                "select * from newt where 'x' like 'y%'", 1, 10))
+
     def test_create_text_index_sql(self):
         from .. import search
         self.assertEqual(


### PR DESCRIPTION
  psycopg2 was trying to do substitutions anyway and choking on ``%``
  characters in ``like`` queries.

- Fixed: Connection.search_batch didn't allow arguments to be omitted.