### PR TITLE
Fix redo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+dist: trusty
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 services:
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
 
 python:
   - pypy-5.4.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,16 @@ Changes
 
 - Fixed: Newt DB couldn't be added to an existing RelStorage database.
 
+- Fixed: when using the updater ``--redo`` option, the
+  ``newt_follow_progress`` table was updated.
+
+- Fixed: when using the updater ``--redo`` option, the
+  ``newt_follow_progress`` was created if it didn't exist.  This was a
+  problem if ``--redo`` was only being used to populate a database to
+  which newt was added.
+
+
+
 0.5.2 (2017-04-01)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,14 +6,14 @@ Changes
 
 - Fixed: Newt DB couldn't be added to an existing RelStorage database.
 
-- Fixed: when using the updater ``--redo`` option, the
-  ``newt_follow_progress`` table was updated.
+- Removed the updater ``--redo`` option. It was implemented incorrectly.
+  Implementing it correctly will be necessary at some point, but for
+  now, we'll punt.
 
-- Fixed: when using the updater ``--redo`` option, the
-  ``newt_follow_progress`` was created if it didn't exist.  This was a
-  problem if ``--redo`` was only being used to populate a database to
-  which newt was added.
-
+- Added a new ``--compute-missing`` option to compute missing Newt
+  records after updating an application from plain RelStorage. (This
+  is similar to the removed ``--redo`` but simpler and narrower in
+  scope.)
 
 
 0.5.2 (2017-04-01)

--- a/doc/topics/for-zodb-users.rst
+++ b/doc/topics/for-zodb-users.rst
@@ -26,3 +26,26 @@ RelStorage ``zodbconvert`` works with Newt DB.
 The next version of Newt will provide a options for batch-computation
 of JSON data, which will allow the conversion of existing Postgres
 RelStorage databases in place.
+
+Updating an existing PostgreSQL RelStorage ZODB application to use Newt DB
+==========================================================================
+
+There are two ways to add Newt DB to an existing PostgreSQL RelStorage
+ZODB application.
+
+a. Update your :doc:`database text configuration <text-configuration>`
+   to include a ``newt`` tag and optionally a ``newtdb`` tag.  After
+   all of your database clients have been updated (and restarted),
+   then new database records will be written to the ``newt`` table.
+   You'll need to run the :doc:`newt updater <updater>` with the
+   ``--compute-missing`` option to write ``newt`` records for your
+   older data:
+
+   .. code-block:: console
+
+      newt-updater --compute-missing CONNECTION_STRING
+
+b. Use the :doc:`Newt DB updater <updater>` to maintain Newt data
+   asynchronously.  This requires no change to your database setup, but
+   requires managing a separate process.  Because updates are
+   asynchronous, Newt JSON data may be slightly out of date at times.

--- a/doc/topics/updater.rst
+++ b/doc/topics/updater.rst
@@ -132,6 +132,17 @@ To use Newt's asynchronous updater:
     psycopg2cffi).  By default, the appropriate driver will be
     selected automatically.
 
+--compute-missing
+    Compute missing newt records.
+
+    Rather than processing new records, process records written up through
+    the current time and stop.  Only missing records are updated.  **This
+    option requires PostgreSQL 9.5 or later.**
+
+    This is used to compute newt records after adding Newt DB to an existing
+    PostgreSQL RelStorage application.
+
+
 Garbage collection
 ==================
 

--- a/doc/topics/updater.rst
+++ b/doc/topics/updater.rst
@@ -109,6 +109,16 @@ To use Newt's asynchronous updater:
   This is a backstop to PostgreSQL's notification. The default timeout
   is 300 seconds.
 
+-m, --transaction-size-limit
+  The target transaction batch size.  This limits (loosely) the number
+  of records processed in a batch. Larger batches incur less overhead,
+  but long-lasting transactions can cause interfere with other
+  processing.  The default is 100 thousand records.
+
+  This option only comes into play when a large number of records have
+  to be processed, typically when first running the updater or using
+  the ``--compute-missing option``.
+
 -T, --remove-delete-trigger
   Remove the Newt DB delete trigger, if it exists.
 

--- a/src/newt/db/_adapter.py
+++ b/src/newt/db/_adapter.py
@@ -62,6 +62,7 @@ class Mover(relstorage.adapters.postgresql.mover.PostgreSQLObjectMover):
             )
 
     _move_json_sql = """
+    LOCK TABLE newt IN SHARE MODE;
     DELETE FROM newt WHERE zoid IN (SELECT zoid FROM temp_store);
 
     INSERT INTO newt (zoid, class_name, ghost_pickle, state)

--- a/src/newt/db/tests/testupdater.py
+++ b/src/newt/db/tests/testupdater.py
@@ -355,9 +355,8 @@ class RedoTests(base.TestCase):
         with self.assertRaises(AssertionError):
             updater.main(['--redo', self.dsn])
 
-        from .. import connection
-
         # create newt table
+        from .. import connection
         connection(self.dsn).close()
 
         # The table is empty:
@@ -375,3 +374,6 @@ class RedoTests(base.TestCase):
 
         # The progres table still doesn't exist
         self.assertFalse(_util.table_exists(cursor, follow.PROGRESS_TABLE))
+
+        cursor.close()
+        conn.close()


### PR DESCRIPTION
Fixes redo by replacing it with something simpler, for a narrower use case:

- Removed the updater ``--redo`` option. It was implemented incorrectly.
  Implementing it correctly will be necessary at some point, but for
  now, we'll punt.

- Added a new ``--compute-missing`` option to compute missing Newt
  records after updating an application from plain RelStorage. (This
  is similar to the removed ``--redo`` but simpler and narrower in
  scope.)